### PR TITLE
fix: better way to test error on space-age

### DIFF
--- a/exercises/practice/space-age/run_test.v
+++ b/exercises/practice/space-age/run_test.v
@@ -39,5 +39,9 @@ fn test_age_on_neptune(){
 }
 
 fn test_age_on_sun(){
-	age(680804807, "Sun") or { assert err.msg() == "Sun is not a valid planet"}
+	if res := age(680804807, "Sun") {
+		assert false, "trying to find age on the sun should return an error"
+	} else {
+		assert err.msg() == "Sun is not a valid planet"
+	}
 }


### PR DESCRIPTION
now if the function does not return an error for the sun, the test fails. I don't believe it did previously