### PR TITLE
fix: wrong file name in nucleotide

### DIFF
--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,7 +1,7 @@
 {
   "authors": ["1ethanhansen"],
   "files": {
-    "solution": ["nucleotides-count.v"],
+    "solution": ["nucleotide-count.v"],
     "test": ["run_test.v"],
     "example": [".meta/example.v"]
   },


### PR DESCRIPTION
Did not mean to push to main! i had typed out git checkout branch add-nucleotide and never hit enter or it didn't register. @ErikSchierboom would it be possible to protect the main branch so it can't be pushed to directly and needs to have a PR into it to merge please? I don't have access to those settings.