### PR TITLE
Add exercise `secret-handshake`

### DIFF
--- a/config.json
+++ b/config.json
@@ -204,30 +204,20 @@
         "difficulty": 4
       },
       {
+       "uuid": "021c6fbd-adac-43a3-b2b9-22bde0ae2968",
+       "slug": "secret-handshake",
+       "name": "Secret Handshake",
+       "practices": [],
+       "prerequisites": [],
+       "difficulty": 3
+      },
+      {
         "uuid": "76b3c5ce-a2b2-4e75-bd2a-bb94e81c2701",
         "slug": "accumulate",
         "name": "Accumulate",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2
-      },
-      {
-        "uuid": "021c6fbd-adac-43a3-b2b9-22bde0ae2968",
-        "slug": "secret-handshake",
-        "name": "Secret Handshake",
-        "practices": [
-          "bitwise",
-          "enum"
-        ],
-        "prerequisites": [
-          "bitwise",
-          "enum",
-          "int",
-          "array",
-          "for",
-          "if"
-        ],
-        "difficulty": 3
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -204,20 +204,30 @@
         "difficulty": 4
       },
       {
-       "uuid": "021c6fbd-adac-43a3-b2b9-22bde0ae2968",
-       "slug": "secret-handshake",
-       "name": "Secret Handshake",
-       "practices": [],
-       "prerequisites": [],
-       "difficulty": 3
-      },
-      {
         "uuid": "76b3c5ce-a2b2-4e75-bd2a-bb94e81c2701",
         "slug": "accumulate",
         "name": "Accumulate",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2
+      },
+      {
+        "uuid": "021c6fbd-adac-43a3-b2b9-22bde0ae2968",
+        "slug": "secret-handshake",
+        "name": "Secret Handshake",
+        "practices": [
+          "bitwise",
+          "enum"
+        ],
+        "prerequisites": [
+          "bitwise",
+          "enum",
+          "int",
+          "array",
+          "for",
+          "if"
+        ],
+        "difficulty": 3
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -204,6 +204,14 @@
         "difficulty": 4
       },
       {
+       "uuid": "021c6fbd-adac-43a3-b2b9-22bde0ae2968",
+       "slug": "secret-handshake",
+       "name": "Secret Handshake",
+       "practices": [],
+       "prerequisites": [],
+       "difficulty": 3
+      },
+      {
         "uuid": "76b3c5ce-a2b2-4e75-bd2a-bb94e81c2701",
         "slug": "accumulate",
         "name": "Accumulate",

--- a/exercises/practice/secret-handshake/.docs/instructions.md
+++ b/exercises/practice/secret-handshake/.docs/instructions.md
@@ -1,0 +1,24 @@
+# Instructions
+
+> There are 10 types of people in the world: Those who understand
+> binary, and those who don't.
+
+You and your fellow cohort of those in the "know" when it comes to binary decide to come up with a secret "handshake".
+
+```text
+00001 = wink
+00010 = double blink
+00100 = close your eyes
+01000 = jump
+
+10000 = Reverse the order of the operations in the secret handshake.
+```
+
+Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.
+
+Here's a couple of examples:
+
+Given the decimal input 3, the function would return the array ["wink", "double blink"] because the decimal number 3 is 2+1 in powers of two and thus `11` in binary.
+
+Let's now examine the input 19 which is 16+2+1 in powers of two and thus `10011` in binary.
+Recalling that the addition of 16 (`10000` in binary) reverses an array and that we already know what array is returned given input 3, the array returned for input 19 is ["double blink", "wink"].

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,0 +1,11 @@
+{
+  "authors": ["natanaelsirqueira"],
+  "files": {
+    "solution": ["secret_handshake.v"],
+    "test": ["run_test.v"],
+    "example": [".meta/example.v"]
+  },
+  "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
+  "source": "Bert, in Mary Poppins",
+  "source_url": "https://www.imdb.com/title/tt0058331/quotes/qt0437047"
+}

--- a/exercises/practice/secret-handshake/.meta/example.v
+++ b/exercises/practice/secret-handshake/.meta/example.v
@@ -1,0 +1,45 @@
+module main
+
+enum Command as u8 {
+	wink
+	double_blink
+	close_your_eyes
+	jump
+	reverse
+}
+
+const code_to_command_map = {
+	0b00001: Command.wink
+	0b00010: Command.double_blink
+	0b00100: Command.close_your_eyes
+	0b01000: Command.jump
+	0b10000: Command.reverse
+}
+
+pub fn commands(encoded_message int) []Command {
+	mut commands := []Command{}
+
+	for code, command in code_to_command_map {
+		if should_apply_command(encoded_message, code) {
+			commands = apply_command(commands, command)
+		}
+	}
+
+	return commands
+}
+
+fn should_apply_command(encoded_message int, command_code int) bool {
+	return encoded_message & command_code == command_code
+}
+
+fn apply_command(commands []Command, command Command) []Command {
+	if command == .reverse {
+		return commands.reverse()
+	}
+
+	mut new_commands := commands.clone()
+
+	new_commands << command
+
+	return new_commands
+}

--- a/exercises/practice/secret-handshake/.meta/tests.toml
+++ b/exercises/practice/secret-handshake/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b8496fbd-6778-468c-8054-648d03c4bb23]
+description = "wink for 1"
+
+[83ec6c58-81a9-4fd1-bfaf-0160514fc0e3]
+description = "double blink for 10"
+
+[0e20e466-3519-4134-8082-5639d85fef71]
+description = "close your eyes for 100"
+
+[b339ddbb-88b7-4b7d-9b19-4134030d9ac0]
+description = "jump for 1000"
+
+[40499fb4-e60c-43d7-8b98-0de3ca44e0eb]
+description = "combine two actions"
+
+[9730cdd5-ef27-494b-afd3-5c91ad6c3d9d]
+description = "reverse two actions"
+
+[0b828205-51ca-45cd-90d5-f2506013f25f]
+description = "reversing one action gives the same action"
+
+[9949e2ac-6c9c-4330-b685-2089ab28b05f]
+description = "reversing no actions still gives no actions"
+
+[23fdca98-676b-4848-970d-cfed7be39f81]
+description = "all possible actions"
+
+[ae8fe006-d910-4d6f-be00-54b7c3799e79]
+description = "reverse all possible actions"
+
+[3d36da37-b31f-4cdb-a396-d93a2ee1c4a5]
+description = "do nothing for zero"

--- a/exercises/practice/secret-handshake/run_test.v
+++ b/exercises/practice/secret-handshake/run_test.v
@@ -1,0 +1,45 @@
+module main
+
+fn test_wink_for_1() {
+	assert commands(1) == [.wink]
+}
+
+fn test_double_blink_for_10() {
+	assert commands(2) == [.double_blink]
+}
+
+fn test_close_your_eyes_for_100() {
+	assert commands(4) == [.close_your_eyes]
+}
+
+fn test_jump_for_1000() {
+	assert commands(8) == [.jump]
+}
+
+fn test_combine_two_actions() {
+	assert commands(3) == [.wink, .double_blink]
+}
+
+fn test_reverse_two_actions() {
+	assert commands(19) == [.double_blink, .wink]
+}
+
+fn test_reversing_one_action_gives_the_same_action() {
+	assert commands(24) == [.jump]
+}
+
+fn test_reversing_no_actions_still_gives_no_actions() {
+	assert commands(16) == []
+}
+
+fn test_all_possible_actions() {
+	assert commands(15) == [.wink, .double_blink, .close_your_eyes, .jump]
+}
+
+fn test_reverse_all_possible_actions() {
+	assert commands(31) == [.jump, .close_your_eyes, .double_blink, .wink]
+}
+
+fn test_do_nothing_for_zero() {
+	assert commands(0) == []
+}

--- a/exercises/practice/secret-handshake/secret_handshake.v
+++ b/exercises/practice/secret-handshake/secret_handshake.v
@@ -1,0 +1,12 @@
+module main
+
+enum Command as u8 {
+	wink
+	double_blink
+	close_your_eyes
+	jump
+}
+
+pub fn commands(encoded_message int) []Command {
+	return []
+}


### PR DESCRIPTION
I speedran the V track this weekend so I figured I'd start adding some exercises. :)

Starting with the ones that were selected for the [12in23 challenge](https://exercism.org/challenges/12in23), Secret Handshake is nice for practicing bit manipulation but I also included an enum for the commands because it makes the solution look better.

Also, I think it's a good idea to start populating the `practices` and `prerequisites` lists before we end up with a plethora of exercises we'd need to revise. I might work on a PR to add them to all the exercises.
