### PR TITLE
[~] fix: [grains] Grains template now uses u64 type, that can hold expected 2^64-1

### DIFF
--- a/exercises/practice/grains/.meta/example.v
+++ b/exercises/practice/grains/.meta/example.v
@@ -1,25 +1,25 @@
 module main
 
-fn grains_on_square(square i64) !i64 {
+fn grains_on_square(square int) !u64 {
 	if !error_if_bad_square(square) {
 		return pow(2, square-1)
 	}
 	return error("square must be between 1 and 64")
 }
 
-fn total_grains_on_board() i64 {
-	return pow(2, 64) - 1
+fn total_grains_on_board() u64 {
+	return 0xFFFFFFFF_FFFFFFFF
 }
 
-fn pow(a i64, b i64) i64 {
-	mut pow := i64(1)
+fn pow(a u64, b int) u64 {
+	mut pow := u64(1)
 	for _ in 0 .. b {
 		pow *= a
 	}
 	return pow
 }
 
-fn error_if_bad_square(square i64) bool {
+fn error_if_bad_square(square int) bool {
 	if square <= 0 || square > 64 {
 		return true
 	}

--- a/exercises/practice/grains/grains.v
+++ b/exercises/practice/grains/grains.v
@@ -1,9 +1,9 @@
 module main
 
-fn grains_on_square(square i64) !i64 {
+fn grains_on_square(square int) !u64 {
 
 }
 
-fn total_grains_on_board() i64 {
+fn total_grains_on_board() u64 {
 	
 }


### PR DESCRIPTION
Why? Right now there is an overflow situation, that accidently doesn't show up, since vlang treats 2^64 as 0 adding -1 seems to be the same as 2^64-1.