### PR TITLE
nth-prime: remove test that only prints the first ten primes

### DIFF
--- a/exercises/practice/nth-prime/run_test.v
+++ b/exercises/practice/nth-prime/run_test.v
@@ -23,9 +23,3 @@ fn test_zeroth_prime() {
 		assert err.msg() == 'n must be greater than 0'
 	}
 }
-
-fn test_print() {
-	for i in 1 .. 10 {
-		println(nth_prime(i)!)
-	}
-}


### PR DESCRIPTION
I figured this was an oversight so thought it was a good idea to remove it since it was adding noise to the test results.