### PR TITLE
Add script to bootstrap practice exercise

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ A good place to start in the docs is to understand how the [Hello World](https:/
 
 #### How to implement a new exercise from start to finish
 
+There are two ways to implement a practice exercise. You can follow all the 13 steps listed below from start to finish, or you can run `./bin/bootstrap_practice_exercise.sh [SLUG]` to create all the files and folders you'll need. This will allow you to skip a few steps and jump right into writing your example solution, but you'll need [bash](https://www.gnu.org/software/bash/) and [jq](https://stedolan.github.io/jq/) to run the script.
+
 1. Pick an exercise from the [problem-specifications](https://github.com/exercism/problem-specifications/tree/main/exercises) repo.
 2. Create a new entry for the exercise in [config.json](./config.json). Include
   - a new UUID for the exercise (generated with `bin/configlet uuid`)

--- a/bin/bootstrap_practice_exercise.sh
+++ b/bin/bootstrap_practice_exercise.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Exit if anything fails.
+set -euo pipefail
+
+# If argument not provided, print usage and exit
+if [ $# -ne 1 ]; then
+    echo "Usage: bin/bootstrap_practice_exercise.sh <exercise-slug>"
+    exit 1
+fi
+
+SLUG="$1"
+exercise_dir="exercises/practice/${SLUG}"
+
+# build configlet
+echo "Fetching latest version of configlet..."
+./bin/fetch-configlet
+
+# Preparing config.json
+echo "Adding instructions and configuration files..."
+NAME=$(echo $SLUG | sed -e 's/-/ /g' -e 's/\b\(.\)/\u\1/g' )
+UUID=$(bin/configlet uuid)
+jq --arg slug "$SLUG" --arg name "$NAME" --arg uuid "$UUID" \
+    '.exercises.practice += [{slug: $slug, name: $name, uuid: $uuid, practices: [], prerequisites: [], difficulty: 5}]' \
+    config.json > config.json.tmp
+# jq always rounds whole numbers, but average_run_time needs to be a float
+sed -i 's/"average_run_time": \([[:digit:]]\+\)$/"average_run_time": \1.0/' config.json.tmp
+mv config.json.tmp config.json
+
+# Create instructions and config files
+./bin/configlet sync --update --yes --docs --metadata --exercise "$SLUG"
+./bin/configlet sync --update --yes --filepaths --exercise "$SLUG"
+./bin/configlet sync --update --tests include --exercise "$SLUG"
+
+# Create V files
+touch $exercise_dir/.meta/example.v
+touch $exercise_dir/$SLUG.v
+touch $exercise_dir/run_test.v

--- a/config.json
+++ b/config.json
@@ -19,9 +19,15 @@
     "average_run_time": 3.0
   },
   "files": {
-    "solution": ["%{kebab_slug}.v"],
-    "test": ["run_test.v"],
-    "example": [".meta/example.v"],
+    "solution": [
+      "%{kebab_slug}.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ],
     "exemplar": []
   },
   "exercises": {
@@ -90,32 +96,32 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
-       },
-       {
+      },
+      {
         "uuid": "df360057-385e-4166-96e1-ed0629c02ca3",
         "slug": "two-fer",
         "name": "Two Fer",
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
-       },
-       {
+      },
+      {
         "uuid": "a9000aca-c372-4ddc-a5d9-cd6afa9e2535",
         "slug": "raindrops",
         "name": "Raindrops",
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
-       },
-       {
+      },
+      {
         "uuid": "24f0d852-3581-4e99-b488-d367d16ff1e7",
         "slug": "grade-school",
         "name": "Grade School",
         "practices": [],
         "prerequisites": [],
         "difficulty": 5
-       },
-       {
+      },
+      {
         "uuid": "27d24b09-71dc-462c-b80d-8408b62c69a1",
         "slug": "nucleotide-count",
         "name": "Nucleotide Count",
@@ -164,7 +170,7 @@
         "difficulty": 8
       },
       {
-        "uuid" : "622a3dba-8893-4f2d-9e05-8aedd68df7a9",
+        "uuid": "622a3dba-8893-4f2d-9e05-8aedd68df7a9",
         "slug": "hamming",
         "name": "Hamming",
         "practices": [],
@@ -204,20 +210,20 @@
         "difficulty": 4
       },
       {
-       "uuid": "021c6fbd-adac-43a3-b2b9-22bde0ae2968",
-       "slug": "secret-handshake",
-       "name": "Secret Handshake",
-       "practices": [],
-       "prerequisites": [],
-       "difficulty": 3
+        "uuid": "021c6fbd-adac-43a3-b2b9-22bde0ae2968",
+        "slug": "secret-handshake",
+        "name": "Secret Handshake",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
       },
       {
-       "uuid": "18752af6-01a0-4125-9f45-e2be034b584c",
-       "slug": "binary-search",
-       "name": "Binary Search",
-       "practices": [],
-       "prerequisites": [],
-       "difficulty": 3
+        "uuid": "18752af6-01a0-4125-9f45-e2be034b584c",
+        "slug": "binary-search",
+        "name": "Binary Search",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
       },
       {
         "uuid": "76b3c5ce-a2b2-4e75-bd2a-bb94e81c2701",


### PR DESCRIPTION
I saw a version of this in other tracks and thought it was a must-have. It will generate the `.docs` and `.meta` directories with all the required files, and also create the V files so you can jump directly into writing the code. In the future, this can be updated to generate the V test cases and the main public function(s) for the exercise as well, which will save even more time.

The `config.json` file gets formatted by `jq` when running the script, so I'm adding the formatted file along with it.