### PR TITLE
Add exercise `linked-list`

### DIFF
--- a/config.json
+++ b/config.json
@@ -248,6 +248,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3
+      },
+      {
+        "uuid": "79f48b51-3e4a-4bac-961a-2d41e2b17215",
+        "slug": "linked-list",
+        "name": "Linked List",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -255,7 +255,7 @@
         "name": "Linked List",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 5
+        "difficulty": 6
       }
     ]
   },

--- a/exercises/practice/linked-list/.docs/instructions.append.md
+++ b/exercises/practice/linked-list/.docs/instructions.append.md
@@ -1,0 +1,10 @@
+# Instructions append
+
+Your list must also implement the following interface:
+
+- `delete` (delete the first occurrence of a specified value)
+- `count` (count the number of items in the list)
+
+The stubs in `linked-list.v` provide the _minimum_ set of interfaces. You may wish to add your own definitions, such as a structure to represent an item in the list.
+
+However, do _not_ use a library to implement this exercise, and do _not_ use an array.

--- a/exercises/practice/linked-list/.docs/instructions.md
+++ b/exercises/practice/linked-list/.docs/instructions.md
@@ -1,0 +1,26 @@
+# Instructions
+
+Implement a doubly linked list.
+
+Like an array, a linked list is a simple linear data structure.
+Several common data types can be implemented using linked lists, like queues, stacks, and associative arrays.
+
+A linked list is a collection of data elements called *nodes*.
+In a *singly linked list* each node holds a value and a link to the next node.
+In a *doubly linked list* each node also holds a link to the previous node.
+
+You will write an implementation of a doubly linked list.
+Implement a Node to hold a value and pointers to the next and previous nodes.
+Then implement a List which holds references to the first and last node and offers an array-like interface for adding and removing items:
+
+- `push` (*insert value at back*);
+- `pop` (*remove value at back*);
+- `shift` (*remove value at front*).
+- `unshift` (*insert value at front*);
+
+To keep your implementation simple, the tests will not cover error conditions.
+Specifically: `pop` or `shift` will never be called on an empty list.
+
+Read more about [linked lists on Wikipedia][linked-lists].
+
+[linked-lists]: https://en.wikipedia.org/wiki/Linked_list

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,0 +1,18 @@
+{
+  "authors": [
+    "hraftery"
+  ],
+  "files": {
+    "solution": [
+      "linked-list.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ]
+  },
+  "blurb": "Implement a doubly linked list.",
+  "source": "Classic computer science topic"
+}

--- a/exercises/practice/linked-list/.meta/example.v
+++ b/exercises/practice/linked-list/.meta/example.v
@@ -1,0 +1,100 @@
+module main
+
+struct Node {
+	value int
+mut:
+	// Warning: see the following for discussion on nil pointer usage:
+	// https://github.com/vlang/v/blob/master/doc/docs.md#structs-with-reference-fields
+	// Ideally these would all be replaced with Option types, but this is not currently possible:
+	// https://github.com/vlang/v/issues/17616
+	prev &Node = unsafe { nil }
+	next &Node = unsafe { nil }
+}
+
+struct LinkedList {
+mut:
+	head &Node = unsafe { nil }
+	tail &Node = unsafe { nil }
+}
+
+pub fn (mut l LinkedList) push(value int) {
+	node := &Node{
+		value: value
+		prev: l.tail
+	}
+	if l.head == unsafe { nil } {
+		l.head = node
+	} else {
+		mut tail := l.tail
+		tail.next = node
+	}
+	l.tail = node
+}
+
+pub fn (mut l LinkedList) pop() int {
+	tail := l.tail
+	if tail.prev == unsafe { nil } { // single element
+		l.head = unsafe { nil }
+		l.tail = unsafe { nil }
+	} else { // multiple elements
+		mut prev := tail.prev
+		prev.next = unsafe { nil }
+		l.tail = prev
+	}
+	return tail.value // tail can now be auto-freed
+}
+
+pub fn (mut l LinkedList) unshift(value int) {
+	node := &Node{
+		value: value
+		next: l.head
+	}
+	if l.tail == unsafe { nil } {
+		l.tail = node
+	} else {
+		mut head := l.head
+		head.prev = node
+	}
+	l.head = node
+}
+
+pub fn (mut l LinkedList) shift() int {
+	head := l.head
+	if head.next == unsafe { nil } { // single element
+		l.head = unsafe { nil }
+		l.tail = unsafe { nil }
+	} else { // multiple elements
+		mut next := head.next
+		next.prev = unsafe { nil }
+		l.head = next
+	}
+	return head.value // head can now be auto-freed
+}
+
+pub fn (l LinkedList) count() int {
+	mut count := 0
+	for node := l.head; node != unsafe { nil }; node = node.next {
+		count++
+	}
+	return count
+}
+
+pub fn (mut l LinkedList) delete(value int) {
+	for node := l.head; node != unsafe { nil }; node = node.next {
+		if node.value == value {
+			if node == l.head {
+				l.head = node.next
+			} else {
+				node.prev.next = node.next
+			}
+			if node == l.tail {
+				l.tail = node.prev
+			} else {
+				node.next.prev = node.prev
+			}
+			// node can now be auto-freed
+			// and now we've done a delete, we're done
+			return
+		}
+	}
+}

--- a/exercises/practice/linked-list/.meta/tests.toml
+++ b/exercises/practice/linked-list/.meta/tests.toml
@@ -1,0 +1,67 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[7f7e3987-b954-41b8-8084-99beca08752c]
+description = "pop gets element from the list"
+
+[c3f67e5d-cfa2-4c3e-a18f-7ce999c3c885]
+description = "push/pop respectively add/remove at the end of the list"
+
+[00ea24ce-4f5c-4432-abb4-cc6e85462657]
+description = "shift gets an element from the list"
+
+[37962ee0-3324-4a29-b588-5a4c861e6564]
+description = "shift gets first element from the list"
+
+[30a3586b-e9dc-43fb-9a73-2770cec2c718]
+description = "unshift adds element at start of the list"
+
+[042f71e4-a8a7-4cf0-8953-7e4f3a21c42d]
+description = "pop, push, shift, and unshift can be used in any order"
+
+[88f65c0c-4532-4093-8295-2384fb2f37df]
+description = "count an empty list"
+
+[fc055689-5cbe-4cd9-b994-02e2abbb40a5]
+description = "count a list with items"
+
+[8272cef5-130d-40ea-b7f6-5ffd0790d650]
+description = "count is correct after mutation"
+
+[229b8f7a-bd8a-4798-b64f-0dc0bb356d95]
+description = "popping to empty doesn't break the list"
+
+[4e1948b4-514e-424b-a3cf-a1ebbfa2d1ad]
+description = "shifting to empty doesn't break the list"
+
+[e8f7c600-d597-4f79-949d-8ad8bae895a6]
+description = "deletes the only element"
+
+[fd65e422-51f3-45c0-9fd0-c33da638f89b]
+description = "deletes the element with the specified value from the list"
+
+[59db191a-b17f-4ab7-9c5c-60711ec1d013]
+description = "deletes the element with the specified value from the list, re-assigns tail"
+
+[58242222-5d39-415b-951d-8128247f8993]
+description = "deletes the element with the specified value from the list, re-assigns head"
+
+[ee3729ee-3405-4bd2-9bad-de0d4aa5d647]
+description = "deletes the first of two elements"
+
+[47e3b3b4-b82c-4c23-8c1a-ceb9b17cb9fb]
+description = "deletes the second of two elements"
+
+[7b420958-f285-4922-b8f9-10d9dcab5179]
+description = "delete does not modify the list if the element is not found"
+
+[7e04828f-6082-44e3-a059-201c63252a76]
+description = "deletes only the first occurrence"

--- a/exercises/practice/linked-list/linked-list.v
+++ b/exercises/practice/linked-list/linked-list.v
@@ -1,0 +1,24 @@
+module main
+
+// define the LinkedList type here
+struct LinkedList {
+}
+
+// implement these methods as a minimum
+pub fn (mut l LinkedList) push(value int) {
+}
+
+pub fn (mut l LinkedList) pop() int {
+}
+
+pub fn (mut l LinkedList) unshift(value int) {
+}
+
+pub fn (mut l LinkedList) shift() int {
+}
+
+pub fn (l LinkedList) count() int {
+}
+
+pub fn (mut l LinkedList) delete(value int) {
+}

--- a/exercises/practice/linked-list/run_test.v
+++ b/exercises/practice/linked-list/run_test.v
@@ -1,0 +1,175 @@
+module main
+
+fn test_pop_gets_element_from_the_list() {
+	mut ll := LinkedList{}
+	ll.push(7)
+	assert ll.pop() == 7
+}
+
+fn test_push_pop_respectively_add_remove_at_the_end_of_the_list() {
+	mut ll := LinkedList{}
+	ll.push(11)
+	ll.push(13)
+	assert ll.pop() == 13
+	assert ll.pop() == 11
+}
+
+fn test_shift_gets_an_element_from_the_list() {
+	mut ll := LinkedList{}
+	ll.push(17)
+	assert ll.shift() == 17
+}
+
+fn test_shift_gets_first_element_from_the_list() {
+	mut ll := LinkedList{}
+	ll.push(23)
+	ll.push(5)
+	assert ll.shift() == 23
+	assert ll.shift() == 5
+}
+
+fn test_unshift_adds_element_at_start_of_the_list() {
+	mut ll := LinkedList{}
+	ll.unshift(23)
+	ll.unshift(5)
+	assert ll.shift() == 5
+	assert ll.shift() == 23
+}
+
+fn test_pop_push_shift_and_unshift_can_be_used_in_any_order() {
+	mut ll := LinkedList{}
+	ll.push(1)
+	ll.push(2)
+	assert ll.pop() == 2
+	ll.push(3)
+	assert ll.shift() == 1
+	ll.unshift(4)
+	ll.push(5)
+	assert ll.shift() == 4
+	assert ll.pop() == 5
+	assert ll.shift() == 3
+}
+
+fn test_count_an_empty_list() {
+	ll := LinkedList{}
+	assert ll.count() == 0
+}
+
+fn test_count_a_list_with_items() {
+	mut ll := LinkedList{}
+	ll.push(37)
+	ll.push(1)
+	assert ll.count() == 2
+}
+
+fn test_count_is_correct_after_mutation() {
+	mut ll := LinkedList{}
+	ll.push(31)
+	assert ll.count() == 1
+	ll.unshift(43)
+	assert ll.count() == 2
+	ll.shift()
+	assert ll.count() == 1
+	ll.pop()
+	assert ll.count() == 0
+}
+
+fn test_popping_to_empty_does_not_break_the_list() {
+	mut ll := LinkedList{}
+	ll.push(41)
+	ll.push(59)
+	ll.pop()
+	ll.pop()
+	ll.push(47)
+	assert ll.count() == 1
+	assert ll.pop() == 47
+}
+
+fn test_shifting_to_empty_does_not_break_the_list() {
+	mut ll := LinkedList{}
+	ll.push(41)
+	ll.push(59)
+	ll.shift()
+	ll.shift()
+	ll.push(47)
+	assert ll.count() == 1
+	assert ll.pop() == 47
+}
+
+fn test_deletes_the_only_element() {
+	mut ll := LinkedList{}
+	ll.push(61)
+	ll.delete(61)
+	assert ll.count() == 0
+}
+
+fn test_deletes_the_element_with_the_specified_value_from_the_list() {
+	mut ll := LinkedList{}
+	ll.push(71)
+	ll.push(83)
+	ll.push(79)
+	ll.delete(83)
+	assert ll.count() == 2
+	assert ll.pop() == 79
+	assert ll.shift() == 71
+}
+
+fn test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_tail() {
+	mut ll := LinkedList{}
+	ll.push(71)
+	ll.push(83)
+	ll.push(79)
+	ll.delete(83)
+	assert ll.count() == 2
+	assert ll.pop() == 79
+	assert ll.pop() == 71
+}
+
+fn test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_head() {
+	mut ll := LinkedList{}
+	ll.push(71)
+	ll.push(83)
+	ll.push(79)
+	ll.delete(83)
+	assert ll.count() == 2
+	assert ll.shift() == 71
+	assert ll.shift() == 79
+}
+
+fn test_deletes_the_first_of_two_elements() {
+	mut ll := LinkedList{}
+	ll.push(97)
+	ll.push(101)
+	ll.delete(97)
+	assert ll.count() == 1
+	assert ll.pop() == 101
+}
+
+fn test_deletes_the_second_of_two_elements() {
+	mut ll := LinkedList{}
+	ll.push(97)
+	ll.push(101)
+	ll.delete(101)
+	assert ll.count() == 1
+	assert ll.pop() == 97
+}
+
+fn test_delete_does_not_modify_the_list_if_the_element_is_not_found() {
+	mut ll := LinkedList{}
+	ll.push(89)
+	ll.delete(103)
+	assert ll.count() == 1
+}
+
+fn test_deletes_only_the_first_occurrence() {
+	mut ll := LinkedList{}
+	ll.push(73)
+	ll.push(9)
+	ll.push(9)
+	ll.push(107)
+	ll.delete(9)
+	assert ll.count() == 3
+	assert ll.pop() == 107
+	assert ll.pop() == 9
+	assert ll.pop() == 73
+}


### PR DESCRIPTION
As in #63 , this is an attempt to add the final recommended exercise. I saw @natanaelsirqueira had been adding them steadily and thought I could do some extra practice by lending a hand. Now I see I'm a few hours late!

I went with `linked-list` instead of `simple-linked-list`, but perhaps it's best to only have one per track? Looking at the implementations, my use of unsafe nil pointers (and discovery of a compiler bug if I don't) might mean `linked-list` is a little more problematic as an exercise for V at the moment. Although, this might simply be a reflection of my naivety with V, and Natanael's trick of keeping a `len` counter might work similarly.

The other discrepancy between the two is that I rated `linked-list` a difficulty 5 (after contemplating a 4) and Natanael gave `simple-linked-list` the same rating. Even though the conceptual challenge is similar (maintaining a list of references) perhaps it makes sense for them to be rated in a way that reflects their names.