### PR TITLE
Add "len" field to simple-linked-list interface

### DIFF
--- a/exercises/practice/simple-linked-list/simple-linked-list.v
+++ b/exercises/practice/simple-linked-list/simple-linked-list.v
@@ -2,6 +2,8 @@ module main
 
 struct LinkedList {
 	// define your data structure here
+mut:
+	len int // maintain the number of elements in the list in this field
 }
 
 fn new() LinkedList {


### PR DESCRIPTION
Provides a potential fix to issue #66 by adding the missing required field to the provided interface.