### PR TITLE
feat: Add exercise ETL (closes #86)

### DIFF
--- a/config.json
+++ b/config.json
@@ -298,6 +298,14 @@
         "difficulty": 3
       },
       {
+        "slug": "etl",
+        "name": "ETL",
+        "uuid": "3d66d6f5-5d74-4d29-872e-e92154df5dd6",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "uuid": "79f48b51-3e4a-4bac-961a-2d41e2b17215",
         "slug": "linked-list",
         "name": "Linked List",

--- a/exercises/practice/etl/.docs/instructions.md
+++ b/exercises/practice/etl/.docs/instructions.md
@@ -1,0 +1,27 @@
+# Instructions
+
+Your task is to change the data format of letters and their point values in the game.
+
+Currently, letters are stored in groups based on their score, in a one-to-many mapping.
+
+- 1 point: "A", "E", "I", "O", "U", "L", "N", "R", "S", "T",
+- 2 points: "D", "G",
+- 3 points: "B", "C", "M", "P",
+- 4 points: "F", "H", "V", "W", "Y",
+- 5 points: "K",
+- 8 points: "J", "X",
+- 10 points: "Q", "Z",
+
+This needs to be changed to store each individual letter with its score in a one-to-one mapping.
+
+- "a" is worth 1 point.
+- "b" is worth 3 points.
+- "c" is worth 3 points.
+- "d" is worth 2 points.
+- etc.
+
+As part of this change, the team has also decided to change the letters to be lower-case rather than upper-case.
+
+~~~~exercism/note
+If you want to look at how the data was previously structured and how it needs to change, take a look at the examples in the test suite.
+~~~~

--- a/exercises/practice/etl/.docs/introduction.md
+++ b/exercises/practice/etl/.docs/introduction.md
@@ -1,0 +1,16 @@
+# Introduction
+
+You work for a company that makes an online multiplayer game called Lexiconia.
+
+To play the game, each player is given 13 letters, which they must rearrange to create words.
+Different letters have different point values, since it's easier to create words with some letters than others.
+
+The game was originally launched in English, but it is very popular, and now the company wants to expand to other languages as well.
+
+Different languages need to support different point values for letters.
+The point values are determined by how often letters are used, compared to other letters in that language.
+
+For example, the letter 'C' is quite common in English, and is only worth 3 points.
+But in Norwegian it's a very rare letter, and is worth 10 points.
+
+To make it easier to add new languages, your team needs to change the way letters and their point values are stored in the game.

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "etl.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ]
+  },
+  "blurb": "Change the data format for scoring a game to more easily add other languages.",
+  "source": "Based on an exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
+  "source_url": "https://turing.edu"
+}

--- a/exercises/practice/etl/.meta/example.v
+++ b/exercises/practice/etl/.meta/example.v
@@ -1,0 +1,12 @@
+module main
+
+fn transform(legacy map[int][]rune) map[rune]int {
+	mut result := map[rune]int{}
+	for score, letters in legacy {
+		for letter in letters {
+			lower_letter := letter.str().to_lower()[0]
+			result[lower_letter] = score
+		}
+	}
+	return result
+}

--- a/exercises/practice/etl/.meta/tests.toml
+++ b/exercises/practice/etl/.meta/tests.toml
@@ -1,0 +1,15 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[78a7a9f9-4490-4a47-8ee9-5a38bb47d28f]
+description = "single letter"
+
+[60dbd000-451d-44c7-bdbb-97c73ac1f497]
+description = "single score with multiple letters"
+
+[f5c5de0c-301f-4fdd-a0e5-df97d4214f54]
+description = "multiple scores with multiple letters"
+
+[5db8ea89-ecb4-4dcd-902f-2b418cc87b9d]
+description = "multiple scores with differing numbers of letters"

--- a/exercises/practice/etl/etl.v
+++ b/exercises/practice/etl/etl.v
@@ -1,0 +1,4 @@
+module main
+
+fn transform(legacy map[int][]rune) map[rune]int {
+}

--- a/exercises/practice/etl/run_test.v
+++ b/exercises/practice/etl/run_test.v
@@ -1,0 +1,80 @@
+module main
+
+fn test_single_letter() {
+	legacy := {
+		1: [`A`]
+	}
+	expected := {
+		`a`: 1
+	}
+	assert transform(legacy) == expected
+}
+
+fn test_single_score_with_multiple_letters() {
+	legacy := {
+		1: [`A`, `E`, `I`, `O`, `U`]
+	}
+	expected := {
+		`a`: 1
+		`e`: 1
+		`i`: 1
+		`o`: 1
+		`u`: 1
+	}
+	assert transform(legacy) == expected
+}
+
+fn test_multiple_scores_with_multiple_letters() {
+	legacy := {
+		1: [`A`, `E`]
+		2: [`D`, `G`]
+	}
+	expected := {
+		`a`: 1
+		`d`: 2
+		`e`: 1
+		`g`: 2
+	}
+	assert transform(legacy) == expected
+}
+
+fn test_multiple_scores_with_differing_numbers_of_letters() {
+	legacy := {
+		1:  [`A`, `E`, `I`, `O`, `U`, `L`, `N`, `R`, `S`, `T`]
+		2:  [`D`, `G`]
+		3:  [`B`, `C`, `M`, `P`]
+		4:  [`F`, `H`, `V`, `W`, `Y`]
+		5:  [`K`]
+		8:  [`J`, `X`]
+		10: [`Q`, `Z`]
+	}
+	expected := {
+		`a`: 1
+		`b`: 3
+		`c`: 3
+		`d`: 2
+		`e`: 1
+		`f`: 4
+		`g`: 2
+		`h`: 4
+		`i`: 1
+		`j`: 8
+		`k`: 5
+		`l`: 1
+		`m`: 3
+		`n`: 1
+		`o`: 1
+		`p`: 3
+		`q`: 10
+		`r`: 1
+		`s`: 1
+		`t`: 1
+		`u`: 1
+		`v`: 4
+		`w`: 4
+		`x`: 8
+		`y`: 4
+		`z`: 10
+	}
+	assert transform(legacy) == expected
+}


### PR DESCRIPTION
Function and argument names, and test cases, are taken from
https://github.com/exercism/problem-specifications/blob/main/exercises/etl/canonical-data.json