### PR TITLE
feat: Add Variable Length Quantity (closes #93)

### DIFF
--- a/config.json
+++ b/config.json
@@ -122,6 +122,14 @@
         "difficulty": 1
       },
       {
+        "slug": "variable-length-quantity",
+        "name": "Variable Length Quantity",
+        "uuid": "7c0a8cb0-22dc-4a2f-bb9f-872716f47cf2",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
         "uuid": "24f0d852-3581-4e99-b488-d367d16ff1e7",
         "slug": "grade-school",
         "name": "Grade School",

--- a/exercises/practice/variable-length-quantity/.docs/instructions.md
+++ b/exercises/practice/variable-length-quantity/.docs/instructions.md
@@ -1,0 +1,34 @@
+# Instructions
+
+Implement variable length quantity encoding and decoding.
+
+The goal of this exercise is to implement [VLQ][vlq] encoding/decoding.
+
+In short, the goal of this encoding is to encode integer values in a way that would save bytes.
+Only the first 7 bits of each byte are significant (right-justified; sort of like an ASCII byte).
+So, if you have a 32-bit value, you have to unpack it into a series of 7-bit bytes.
+Of course, you will have a variable number of bytes depending upon your integer.
+To indicate which is the last byte of the series, you leave bit #7 clear.
+In all of the preceding bytes, you set bit #7.
+
+So, if an integer is between `0-127`, it can be represented as one byte.
+Although VLQ can deal with numbers of arbitrary sizes, for this exercise we will restrict ourselves to only numbers that fit in a 32-bit unsigned integer.
+Here are examples of integers as 32-bit values, and the variable length quantities that they translate to:
+
+```text
+ NUMBER        VARIABLE QUANTITY
+00000000              00
+00000040              40
+0000007F              7F
+00000080             81 00
+00002000             C0 00
+00003FFF             FF 7F
+00004000           81 80 00
+00100000           C0 80 00
+001FFFFF           FF FF 7F
+00200000          81 80 80 00
+08000000          C0 80 80 00
+0FFFFFFF          FF FF FF 7F
+```
+
+[vlq]: https://en.wikipedia.org/wiki/Variable-length_quantity

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "variable-length-quantity.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ]
+  },
+  "blurb": "Implement variable length quantity encoding and decoding.",
+  "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
+  "source_url": "https://splice.com"
+}

--- a/exercises/practice/variable-length-quantity/.meta/example.v
+++ b/exercises/practice/variable-length-quantity/.meta/example.v
@@ -1,0 +1,40 @@
+module main
+
+fn encode(integers []u32) []u8 {
+	mut result := []u8{}
+	for integer in integers {
+		mut encoding := []u8{}
+		mut current := integer
+		encoding << u8(current & 0x7f)
+		current >>>= 7
+		for current != 0 {
+			encoding << u8(0x80 | current)
+			current >>>= 7
+		}
+
+		encoding.reverse_in_place()
+		result << encoding
+	}
+	return result
+}
+
+fn decode(integers []u8) ![]u32 {
+	mut result := []u32{}
+	mut current := u32(0)
+	mut complete := true
+	for integer in integers {
+		current |= integer & 0x7f
+		if (integer & 0x80) != 0 {
+			current <<= 7
+			complete = false
+		} else {
+			result << current
+			current = 0
+			complete = true
+		}
+	}
+	if !complete {
+		return error('incomplete sequence')
+	}
+	return result
+}

--- a/exercises/practice/variable-length-quantity/.meta/tests.toml
+++ b/exercises/practice/variable-length-quantity/.meta/tests.toml
@@ -1,0 +1,81 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[35c9db2e-f781-4c52-b73b-8e76427defd0]
+description = "Encode a series of integers, producing a series of bytes. -> zero"
+
+[be44d299-a151-4604-a10e-d4b867f41540]
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary single byte"
+
+[ea399615-d274-4af6-bbef-a1c23c9e1346]
+description = "Encode a series of integers, producing a series of bytes. -> largest single byte"
+
+[77b07086-bd3f-4882-8476-8dcafee79b1c]
+description = "Encode a series of integers, producing a series of bytes. -> smallest double byte"
+
+[63955a49-2690-4e22-a556-0040648d6b2d]
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary double byte"
+
+[29da7031-0067-43d3-83a7-4f14b29ed97a]
+description = "Encode a series of integers, producing a series of bytes. -> largest double byte"
+
+[3345d2e3-79a9-4999-869e-d4856e3a8e01]
+description = "Encode a series of integers, producing a series of bytes. -> smallest triple byte"
+
+[5df0bc2d-2a57-4300-a653-a75ee4bd0bee]
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary triple byte"
+
+[f51d8539-312d-4db1-945c-250222c6aa22]
+description = "Encode a series of integers, producing a series of bytes. -> largest triple byte"
+
+[da78228b-544f-47b7-8bfe-d16b35bbe570]
+description = "Encode a series of integers, producing a series of bytes. -> smallest quadruple byte"
+
+[11ed3469-a933-46f1-996f-2231e05d7bb6]
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary quadruple byte"
+
+[d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c]
+description = "Encode a series of integers, producing a series of bytes. -> largest quadruple byte"
+
+[91a18b33-24e7-4bfb-bbca-eca78ff4fc47]
+description = "Encode a series of integers, producing a series of bytes. -> smallest quintuple byte"
+
+[5f34ff12-2952-4669-95fe-2d11b693d331]
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary quintuple byte"
+
+[7489694b-88c3-4078-9864-6fe802411009]
+description = "Encode a series of integers, producing a series of bytes. -> maximum 32-bit integer input"
+
+[f9b91821-cada-4a73-9421-3c81d6ff3661]
+description = "Encode a series of integers, producing a series of bytes. -> two single-byte values"
+
+[68694449-25d2-4974-ba75-fa7bb36db212]
+description = "Encode a series of integers, producing a series of bytes. -> two multi-byte values"
+
+[51a06b5c-de1b-4487-9a50-9db1b8930d85]
+description = "Encode a series of integers, producing a series of bytes. -> many multi-byte values"
+
+[baa73993-4514-4915-bac0-f7f585e0e59a]
+description = "Decode a series of bytes, producing a series of integers. -> one byte"
+
+[72e94369-29f9-46f2-8c95-6c5b7a595aee]
+description = "Decode a series of bytes, producing a series of integers. -> two bytes"
+
+[df5a44c4-56f7-464e-a997-1db5f63ce691]
+description = "Decode a series of bytes, producing a series of integers. -> three bytes"
+
+[1bb58684-f2dc-450a-8406-1f3452aa1947]
+description = "Decode a series of bytes, producing a series of integers. -> four bytes"
+
+[cecd5233-49f1-4dd1-a41a-9840a40f09cd]
+description = "Decode a series of bytes, producing a series of integers. -> maximum 32-bit integer"
+
+[e7d74ba3-8b8e-4bcb-858d-d08302e15695]
+description = "Decode a series of bytes, producing a series of integers. -> incomplete sequence causes error"
+
+[aa378291-9043-4724-bc53-aca1b4a3fcb6]
+description = "Decode a series of bytes, producing a series of integers. -> incomplete sequence causes error, even if value is zero"
+
+[a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee]
+description = "Decode a series of bytes, producing a series of integers. -> multiple values"

--- a/exercises/practice/variable-length-quantity/run_test.v
+++ b/exercises/practice/variable-length-quantity/run_test.v
@@ -1,0 +1,165 @@
+module main
+
+fn test_zero() {
+	integers := [u32(0x0)]
+	expected := [u8(0x0)]
+	assert encode(integers) == expected
+}
+
+fn test_arbitrary_single_byte() {
+	integers := [u32(0x40)]
+	expected := [u8(0x40)]
+	assert encode(integers) == expected
+}
+
+fn test_largest_single_byte() {
+	integers := [u32(0x7f)]
+	expected := [u8(0x7f)]
+	assert encode(integers) == expected
+}
+
+fn test_smallest_double_byte() {
+	integers := [u32(0x80)]
+	expected := [u8(0x81), 0x0]
+	assert encode(integers) == expected
+}
+
+fn test_arbitrary_double_byte() {
+	integers := [u32(0x2000)]
+	expected := [u8(0xc0), 0x0]
+	assert encode(integers) == expected
+}
+
+fn test_largest_double_byte() {
+	integers := [u32(0x3fff)]
+	expected := [u8(0xff), 0x7f]
+	assert encode(integers) == expected
+}
+
+fn test_smallest_triple_byte() {
+	integers := [u32(0x4000)]
+	expected := [u8(0x81), 0x80, 0x0]
+	assert encode(integers) == expected
+}
+
+fn test_arbitrary_triple_byte() {
+	integers := [u32(0x100000)]
+	expected := [u8(0xc0), 0x80, 0x0]
+	assert encode(integers) == expected
+}
+
+fn test_largest_triple_byte() {
+	integers := [u32(0x1fffff)]
+	expected := [u8(0xff), 0xff, 0x7f]
+	assert encode(integers) == expected
+}
+
+fn test_smallest_quadruple_byte() {
+	integers := [u32(0x200000)]
+	expected := [u8(0x81), 0x80, 0x80, 0x0]
+	assert encode(integers) == expected
+}
+
+fn test_arbitrary_quadruple_byte() {
+	integers := [u32(0x8000000)]
+	expected := [u8(0xc0), 0x80, 0x80, 0x0]
+	assert encode(integers) == expected
+}
+
+fn test_largest_quadruple_byte() {
+	integers := [u32(0xfffffff)]
+	expected := [u8(0xff), 0xff, 0xff, 0x7f]
+	assert encode(integers) == expected
+}
+
+fn test_smallest_quintuple_byte() {
+	integers := [u32(0x10000000)]
+	expected := [u8(0x81), 0x80, 0x80, 0x80, 0x0]
+	assert encode(integers) == expected
+}
+
+fn test_arbitrary_quintuple_byte() {
+	integers := [u32(0xff000000)]
+	expected := [u8(0x8f), 0xf8, 0x80, 0x80, 0x0]
+	assert encode(integers) == expected
+}
+
+fn test_maximum_32_bit_integer_input() {
+	integers := [u32(0xffffffff)]
+	expected := [u8(0x8f), 0xff, 0xff, 0xff, 0x7f]
+	assert encode(integers) == expected
+}
+
+fn test_two_single_byte_values() {
+	integers := [u32(0x40), 0x7f]
+	expected := [u8(0x40), 0x7f]
+	assert encode(integers) == expected
+}
+
+fn test_two_multi_byte_values() {
+	integers := [u32(0x4000), 0x123456]
+	expected := [u8(0x81), 0x80, 0x0, 0xc8, 0xe8, 0x56]
+	assert encode(integers) == expected
+}
+
+fn test_many_multi_byte_values() {
+	integers := [u32(0x2000), 0x123456, 0xfffffff, 0x0, 0x3fff, 0x4000]
+	expected := [u8(0xc0), 0x0, 0xc8, 0xe8, 0x56, 0xff, 0xff, 0xff, 0x7f, 0x0, 0xff, 0x7f, 0x81,
+		0x80, 0x0]
+	assert encode(integers) == expected
+}
+
+fn test_one_byte() {
+	integers := [u8(0x7f)]
+	expected := [u32(0x7f)]
+	assert decode(integers)! == expected
+}
+
+fn test_two_bytes() {
+	integers := [u8(0xc0), 0x0]
+	expected := [u32(0x2000)]
+	assert decode(integers)! == expected
+}
+
+fn test_three_bytes() {
+	integers := [u8(0xff), 0xff, 0x7f]
+	expected := [u32(0x1fffff)]
+	assert decode(integers)! == expected
+}
+
+fn test_four_bytes() {
+	integers := [u8(0x81), 0x80, 0x80, 0x0]
+	expected := [u32(0x200000)]
+	assert decode(integers)! == expected
+}
+
+fn test_maximum_32_bit_integer() {
+	integers := [u8(0x8f), 0xff, 0xff, 0xff, 0x7f]
+	expected := [u32(0xffffffff)]
+	assert decode(integers)! == expected
+}
+
+fn test_incomplete_sequence_causes_error() {
+	integers := [u8(0xff)]
+	if res := decode(integers) {
+		assert false, 'incomplete sequence should return an error'
+	} else {
+		assert err.msg() == 'incomplete sequence'
+	}
+}
+
+fn test_incomplete_sequence_causes_error_even_if_value_is_zero() {
+	integers := [u8(0x80)]
+	if res := decode(integers) {
+		assert false, 'incomplete sequence, even if value zero, should return an error'
+	} else {
+		assert err.msg() == 'incomplete sequence'
+	}
+}
+
+fn test_multiple_values() {
+	integers := [u8(0xc0), 0x0, 0xc8, 0xe8, 0x56, 0xff, 0xff, 0xff, 0x7f, 0x0, 0xff, 0x7f, 0x81,
+		0x80, 0x0]
+	expected := [u32(0x2000), 0x123456, 0xfffffff, 0x0, 0x3fff, 0x4000]
+	assert decode(integers)! == expected
+}

--- a/exercises/practice/variable-length-quantity/variable-length-quantity.v
+++ b/exercises/practice/variable-length-quantity/variable-length-quantity.v
@@ -1,0 +1,7 @@
+module main
+
+fn encode(integers []u32) []u8 {
+}
+
+fn decode(integers []u8) ![]u32 {
+}


### PR DESCRIPTION
Test cases use hexadecimal literals, as suggested in
https://github.com/exercism/problem-specifications/blob/main/exercises/variable-length-quantity/canonical-data.json

Function and argument names, and test cases, are taken from the above file.
