### PR TITLE
feat: Add Atbash Cipher (closes #102)

### DIFF
--- a/config.json
+++ b/config.json
@@ -226,6 +226,14 @@
         "difficulty": 1
       },
       {
+        "slug": "atbash-cipher",
+        "name": "Atbash Cipher",
+        "uuid": "53e57ac4-f709-4a4b-ba87-cb3e561e191b",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4
+      },
+      {
         "uuid": "3e9f83c6-6425-44a6-a57a-88171f11c40e",
         "slug": "meetup",
         "name": "Meetup",

--- a/exercises/practice/atbash-cipher/.docs/instructions.md
+++ b/exercises/practice/atbash-cipher/.docs/instructions.md
@@ -1,0 +1,27 @@
+# Instructions
+
+Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+
+The Atbash cipher is a simple substitution cipher that relies on transposing all the letters in the alphabet such that the resulting alphabet is backwards.
+The first letter is replaced with the last letter, the second with the second-last, and so on.
+
+An Atbash cipher for the Latin alphabet would be as follows:
+
+```text
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: zyxwvutsrqponmlkjihgfedcba
+```
+
+It is a very weak cipher because it only has one possible key, and it is a simple mono-alphabetic substitution cipher.
+However, this may not have been an issue in the cipher's time.
+
+Ciphertext is written out in groups of fixed length, the traditional group size being 5 letters, leaving numbers unchanged, and punctuation is excluded.
+This is to make it harder to guess things based on word boundaries.
+All text will be encoded as lowercase letters.
+
+## Examples
+
+- Encoding `test` gives `gvhg`
+- Encoding `x123 yes` gives `c123b vh`
+- Decoding `gvhg` gives `test`
+- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "atbash-cipher.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ]
+  },
+  "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Atbash"
+}

--- a/exercises/practice/atbash-cipher/.meta/example.v
+++ b/exercises/practice/atbash-cipher/.meta/example.v
@@ -1,0 +1,39 @@
+module main
+
+import strings
+
+fn replacement(ch u8) ?u8 {
+	if `0` <= ch && ch <= `9` {
+		return ch
+	}
+	if `A` <= ch && ch <= `Z` {
+		return u8(`a` + `Z` - ch)
+	}
+	if `a` <= ch && ch <= `z` {
+		return u8(`a` + `z` - ch)
+	}
+	return none
+}
+
+fn encode(phrase string) string {
+	mut builder := strings.new_builder(phrase.len * 6 / 5)
+	for ch in phrase {
+		if encoded_ch := replacement(ch) {
+			if builder.len % 6 == 5 {
+				builder.write_u8(u8(` `))
+			}
+			builder.write_u8(encoded_ch)
+		}
+	}
+	return builder.str()
+}
+
+fn decode(phrase string) string {
+	mut builder := strings.new_builder(phrase.len)
+	for ch in phrase {
+		if decoded_ch := replacement(ch) {
+			builder.write_u8(decoded_ch)
+		}
+	}
+	return builder.str()
+}

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -1,0 +1,45 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
+description = "encode -> encode yes"
+
+[b4ffe781-ea81-4b74-b268-cc58ba21c739]
+description = "encode -> encode no"
+
+[10e48927-24ab-4c4d-9d3f-3067724ace00]
+description = "encode -> encode OMG"
+
+[d59b8bc3-509a-4a9a-834c-6f501b98750b]
+description = "encode -> encode spaces"
+
+[31d44b11-81b7-4a94-8b43-4af6a2449429]
+description = "encode -> encode mindblowingly"
+
+[d503361a-1433-48c0-aae0-d41b5baa33ff]
+description = "encode -> encode numbers"
+
+[79c8a2d5-0772-42d4-b41b-531d0b5da926]
+description = "encode -> encode deep thought"
+
+[9ca13d23-d32a-4967-a1fd-6100b8742bab]
+description = "encode -> encode all the letters"
+
+[bb50e087-7fdf-48e7-9223-284fe7e69851]
+description = "decode -> decode exercism"
+
+[ac021097-cd5d-4717-8907-b0814b9e292c]
+description = "decode -> decode a sentence"
+
+[18729de3-de74-49b8-b68c-025eaf77f851]
+description = "decode -> decode numbers"
+
+[0f30325f-f53b-415d-ad3e-a7a4f63de034]
+description = "decode -> decode all the letters"
+
+[39640287-30c6-4c8c-9bac-9d613d1a5674]
+description = "decode -> decode with too many spaces"
+
+[b34edf13-34c0-49b5-aa21-0768928000d5]
+description = "decode -> decode with no spaces"

--- a/exercises/practice/atbash-cipher/atbash-cipher.v
+++ b/exercises/practice/atbash-cipher/atbash-cipher.v
@@ -1,0 +1,7 @@
+module main
+
+fn encode(phrase string) string {
+}
+
+fn decode(phrase string) string {
+}

--- a/exercises/practice/atbash-cipher/run_test.v
+++ b/exercises/practice/atbash-cipher/run_test.v
@@ -1,0 +1,85 @@
+module main
+
+fn test_encode_yes() {
+	phrase := 'yes'
+	expect := 'bvh'
+	assert encode(phrase) == expect
+}
+
+fn test_encode_no() {
+	phrase := 'no'
+	expect := 'ml'
+	assert encode(phrase) == expect
+}
+
+fn test_encode_omg() {
+	phrase := 'OMG'
+	expect := 'lnt'
+	assert encode(phrase) == expect
+}
+
+fn test_encode_spaces() {
+	phrase := 'O M G'
+	expect := 'lnt'
+	assert encode(phrase) == expect
+}
+
+fn test_encode_mindblowingly() {
+	phrase := 'mindblowingly'
+	expect := 'nrmwy oldrm tob'
+	assert encode(phrase) == expect
+}
+
+fn test_encode_numbers() {
+	phrase := 'Testing,1 2 3, testing.'
+	expect := 'gvhgr mt123 gvhgr mt'
+	assert encode(phrase) == expect
+}
+
+fn test_encode_deep_thought() {
+	phrase := 'Truth is fiction.'
+	expect := 'gifgs rhurx grlm'
+	assert encode(phrase) == expect
+}
+
+fn test_encode_all_the_letters() {
+	phrase := 'The quick brown fox jumps over the lazy dog.'
+	expect := 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
+	assert encode(phrase) == expect
+}
+
+fn test_decode_exercism() {
+	phrase := 'vcvix rhn'
+	expect := 'exercism'
+	assert decode(phrase) == expect
+}
+
+fn test_decode_a_sentence() {
+	phrase := 'zmlyh gzxov rhlug vmzhg vkkrm thglm v'
+	expect := 'anobstacleisoftenasteppingstone'
+	assert decode(phrase) == expect
+}
+
+fn test_decode_numbers() {
+	phrase := 'gvhgr mt123 gvhgr mt'
+	expect := 'testing123testing'
+	assert decode(phrase) == expect
+}
+
+fn test_decode_all_the_letters() {
+	phrase := 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
+	expect := 'thequickbrownfoxjumpsoverthelazydog'
+	assert decode(phrase) == expect
+}
+
+fn test_decode_with_too_many_spaces() {
+	phrase := 'vc vix    r hn'
+	expect := 'exercism'
+	assert decode(phrase) == expect
+}
+
+fn test_decode_with_no_spaces() {
+	phrase := 'zmlyhgzxovrhlugvmzhgvkkrmthglmv'
+	expect := 'anobstacleisoftenasteppingstone'
+	assert decode(phrase) == expect
+}


### PR DESCRIPTION
Function and argument names, and test cases, are taken from
https://github.com/exercism/problem-specifications/blob/main/exercises/atbash-cipher/canonical-data.json