### PR TITLE
feat: Add Acronym (closes #107)

### DIFF
--- a/config.json
+++ b/config.json
@@ -202,6 +202,14 @@
         "difficulty": 4
       },
       {
+        "slug": "acronym",
+        "name": "Acronym",
+        "uuid": "0a23399d-b212-4453-b4b8-9c7b57d46e37",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "uuid": "d229850d-421a-47bc-a8ff-df73a4c3b72b",
         "slug": "queen-attack",
         "name": "Queen Attack",

--- a/exercises/practice/acronym/.docs/instructions.md
+++ b/exercises/practice/acronym/.docs/instructions.md
@@ -1,0 +1,17 @@
+# Instructions
+
+Convert a phrase to its acronym.
+
+Techies love their TLA (Three Letter Acronyms)!
+
+Help generate some jargon by writing a program that converts a long name like Portable Network Graphics to its acronym (PNG).
+
+Punctuation is handled as follows: hyphens are word separators (like whitespace); all other punctuation can be removed from the input.
+
+For example:
+
+|Input|Output|
+|-|-|
+|As Soon As Possible|ASAP|
+|Liquid-crystal display|LCD|
+|Thank George It's Friday!|TGIF|

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "acronym.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ]
+  },
+  "blurb": "Convert a long phrase to its acronym.",
+  "source": "Julien Vanier",
+  "source_url": "https://github.com/monkbroc"
+}

--- a/exercises/practice/acronym/.meta/example.v
+++ b/exercises/practice/acronym/.meta/example.v
@@ -1,0 +1,19 @@
+module main
+
+import strings
+
+fn abbreviate(phrase string) string {
+	mut builder := strings.new_builder(10)
+	mut in_word := false
+	for ch in phrase.to_upper() {
+		if `A` <= ch && ch <= `Z` {
+			if !in_word {
+				builder.write_u8(ch)
+				in_word = true
+			}
+		} else if ch == `-` || ch.is_space() {
+			in_word = false
+		}
+	}
+	return builder.str()
+}

--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -1,0 +1,30 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
+description = "basic"
+
+[79ae3889-a5c0-4b01-baf0-232d31180c08]
+description = "lowercase words"
+
+[ec7000a7-3931-4a17-890e-33ca2073a548]
+description = "punctuation"
+
+[32dd261c-0c92-469a-9c5c-b192e94a63b0]
+description = "all caps word"
+
+[ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
+description = "punctuation without whitespace"
+
+[0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
+description = "very long abbreviation"
+
+[6a078f49-c68d-4b7b-89af-33a1a98c28cc]
+description = "consecutive delimiters"
+
+[5118b4b1-4572-434c-8d57-5b762e57973e]
+description = "apostrophes"
+
+[adc12eab-ec2d-414f-b48c-66a4fc06cdef]
+description = "underscore emphasis"

--- a/exercises/practice/acronym/acronym.v
+++ b/exercises/practice/acronym/acronym.v
@@ -1,0 +1,4 @@
+module main
+
+fn abbreviate(phrase string) string {
+}

--- a/exercises/practice/acronym/run_test.v
+++ b/exercises/practice/acronym/run_test.v
@@ -1,0 +1,46 @@
+module main
+
+fn test_basic() {
+	phrase := 'Portable Network Graphics'
+	assert abbreviate(phrase) == 'PNG'
+}
+
+fn test_lowercase_words() {
+	phrase := 'Ruby on Rails'
+	assert abbreviate(phrase) == 'ROR'
+}
+
+fn test_punctuation() {
+	phrase := 'First In, First Out'
+	assert abbreviate(phrase) == 'FIFO'
+}
+
+fn test_all_caps_word() {
+	phrase := 'GNU Image Manipulation Program'
+	assert abbreviate(phrase) == 'GIMP'
+}
+
+fn test_punctuation_without_whitespace() {
+	phrase := 'Complementary metal-oxide semiconductor'
+	assert abbreviate(phrase) == 'CMOS'
+}
+
+fn test_very_long_abbreviation() {
+	phrase := 'Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me'
+	assert abbreviate(phrase) == 'ROTFLSHTMDCOALM'
+}
+
+fn test_consecutive_delimiters() {
+	phrase := 'Something - I made up from thin air'
+	assert abbreviate(phrase) == 'SIMUFTA'
+}
+
+fn test_apostrophes() {
+	phrase := "Halley's Comet"
+	assert abbreviate(phrase) == 'HC'
+}
+
+fn test_underscore_emphasis() {
+	phrase := 'The Road _Not_ Taken'
+	assert abbreviate(phrase) == 'TRNT'
+}


### PR DESCRIPTION
Function and argument names, and test cases, are taken from
https://github.com/exercism/problem-specifications/blob/main/exercises/acronym/canonical-data.json