### PR TITLE
feat: Add Resistor Color Duo (closes #117)

### DIFF
--- a/config.json
+++ b/config.json
@@ -290,6 +290,14 @@
         "difficulty": 5
       },
       {
+        "slug": "resistor-color-duo",
+        "name": "Resistor Color Duo",
+        "uuid": "6f955919-1478-4296-ae5c-8c3caf06d614",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "uuid": "0a1673d3-a5b2-4a82-aa96-2e2070b1e5e2",
         "slug": "clock",
         "name": "Clock",

--- a/exercises/practice/resistor-color-duo/.docs/instructions.md
+++ b/exercises/practice/resistor-color-duo/.docs/instructions.md
@@ -1,0 +1,33 @@
+# Instructions
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know two things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+Each band has a position and a numeric value.
+
+The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands.
+The program will take color names as input and output a two digit number, even if the input is more than two colors!
+
+The band colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+From the example above:
+brown-green should return 15
+brown-green-violet should return 15 too, ignoring the third color.

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "resistor-color-duo.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ]
+  },
+  "blurb": "Convert color codes, as used on resistors, to a numeric value.",
+  "source": "Maud de Vries, Erik Schierboom",
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1464"
+}

--- a/exercises/practice/resistor-color-duo/.meta/example.v
+++ b/exercises/practice/resistor-color-duo/.meta/example.v
@@ -1,0 +1,23 @@
+module main
+
+fn value(colors []string) int {
+	assert colors.len >= 2
+	first := all_colors.index(colors[0])
+	assert first >= 0
+	second := all_colors.index(colors[1])
+	assert second >= 0
+	return first * 10 + second
+}
+
+const all_colors = [
+	'black',
+	'brown',
+	'red',
+	'orange',
+	'yellow',
+	'green',
+	'blue',
+	'violet',
+	'grey',
+	'white',
+]

--- a/exercises/practice/resistor-color-duo/.meta/tests.toml
+++ b/exercises/practice/resistor-color-duo/.meta/tests.toml
@@ -1,0 +1,24 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[ce11995a-5b93-4950-a5e9-93423693b2fc]
+description = "Brown and black"
+
+[7bf82f7a-af23-48ba-a97d-38d59406a920]
+description = "Blue and grey"
+
+[f1886361-fdfd-4693-acf8-46726fe24e0c]
+description = "Yellow and violet"
+
+[b7a6cbd2-ae3c-470a-93eb-56670b305640]
+description = "White and red"
+
+[77a8293d-2a83-4016-b1af-991acc12b9fe]
+description = "Orange and orange"
+
+[0c4fb44f-db7c-4d03-afa8-054350f156a8]
+description = "Ignore additional colors"
+
+[4a8ceec5-0ab4-4904-88a4-daf953a5e818]
+description = "Black and brown, one-digit"

--- a/exercises/practice/resistor-color-duo/resistor-color-duo.v
+++ b/exercises/practice/resistor-color-duo/resistor-color-duo.v
@@ -1,0 +1,4 @@
+module main
+
+fn value(colors []string) int {
+}

--- a/exercises/practice/resistor-color-duo/run_test.v
+++ b/exercises/practice/resistor-color-duo/run_test.v
@@ -1,0 +1,29 @@
+module main
+
+fn test_brown_and_black() {
+	assert value(['brown', 'black']) == 10
+}
+
+fn test_blue_and_grey() {
+	assert value(['blue', 'grey']) == 68
+}
+
+fn test_yellow_and_violet() {
+	assert value(['yellow', 'violet']) == 47
+}
+
+fn test_white_and_red() {
+	assert value(['white', 'red']) == 92
+}
+
+fn test_orange_and_orange() {
+	assert value(['orange', 'orange']) == 33
+}
+
+fn test_ignore_additional_colors() {
+	assert value(['green', 'brown', 'orange']) == 51
+}
+
+fn test_black_and_brown_one_digit() {
+	assert value(['black', 'brown']) == 1
+}


### PR DESCRIPTION
Function and argument names, and test cases, are taken from
https://github.com/exercism/problem-specifications/blob/main/exercises/resistor-color-duo/canonical-data.json