### PR TITLE
fix: Update handling of options in Say

### DIFF
--- a/exercises/practice/say/.meta/example.v
+++ b/exercises/practice/say/.meta/example.v
@@ -70,8 +70,8 @@ fn say3(num int, units ?string, mut builder strings.Builder) {
 	}
 	say2(num % 100, mut builder)
 
-	if units != none {
-		builder.write_string(units)
+	if suffix := units {
+		builder.write_string(suffix)
 	}
 }
 


### PR DESCRIPTION
Fix a compile error in example solution.

(With a recent update to the V compiler, the example solution for the Say exercise no longer compiles.)
