### PR TITLE
feat: Add Rail Fence Cipher (closes #91)

### DIFF
--- a/config.json
+++ b/config.json
@@ -418,6 +418,14 @@
         "difficulty": 5
       },
       {
+        "slug": "rail-fence-cipher",
+        "name": "Rail Fence Cipher",
+        "uuid": "7fbfaabf-a231-4e5c-a005-b4ea5299be63",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
         "slug": "palindrome-products",
         "name": "Palindrome Products",
         "uuid": "23f4a69b-9d5a-4dd3-b8d9-d4fc937241d2",

--- a/exercises/practice/rail-fence-cipher/.docs/instructions.md
+++ b/exercises/practice/rail-fence-cipher/.docs/instructions.md
@@ -1,0 +1,57 @@
+# Instructions
+
+Implement encoding and decoding for the rail fence cipher.
+
+The Rail Fence cipher is a form of transposition cipher that gets its name from the way in which it's encoded.
+It was already used by the ancient Greeks.
+
+In the Rail Fence cipher, the message is written downwards on successive "rails" of an imaginary fence, then moving up when we get to the bottom (like a zig-zag).
+Finally the message is then read off in rows.
+
+For example, using three "rails" and the message "WE ARE DISCOVERED FLEE AT ONCE", the cipherer writes out:
+
+```text
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. E . R . D . S . O . E . E . F . E . A . O . C .
+. . A . . . I . . . V . . . D . . . E . . . N . .
+```
+
+Then reads off:
+
+```text
+WECRLTEERDSOEEFEAOCAIVDEN
+```
+
+To decrypt a message you take the zig-zag shape and fill the ciphertext along the rows.
+
+```text
+? . . . ? . . . ? . . . ? . . . ? . . . ? . . . ?
+. ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? .
+. . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
+```
+
+The first row has seven spots that can be filled with "WECRLTE".
+
+```text
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? .
+. . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
+```
+
+Now the 2nd row takes "ERDSOEEFEAOC".
+
+```text
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. E . R . D . S . O . E . E . F . E . A . O . C .
+. . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
+```
+
+Leaving "AIVDEN" for the last row.
+
+```text
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. E . R . D . S . O . E . E . F . E . A . O . C .
+. . A . . . I . . . V . . . D . . . E . . . N . .
+```
+
+If you now read along the zig-zag shape you can read the original message.

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "rail-fence-cipher.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ]
+  },
+  "blurb": "Implement encoding and decoding for the rail fence cipher.",
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher"
+}

--- a/exercises/practice/rail-fence-cipher/.meta/example.v
+++ b/exercises/practice/rail-fence-cipher/.meta/example.v
@@ -1,0 +1,85 @@
+module main
+
+struct RailIterator {
+	rails int
+mut:
+	count int
+	rail  int
+	delta int = 1
+}
+
+fn (mut iter RailIterator) next() ?int {
+	if iter.count == 0 {
+		return none
+	}
+	iter.count--
+
+	defer {
+		iter.rail += iter.delta
+		if iter.rail == 0 || iter.rail == iter.rails - 1 {
+			iter.delta = -iter.delta
+		}
+	}
+	return iter.rail
+}
+
+fn row_offsets(msg_length int, rails int) []int {
+	assert rails > 1
+
+	period := 2 * (rails - 1)
+	cycles := msg_length / period
+	mut row_lengths := []int{len: rails, init: 2 * cycles}
+	row_lengths[0] = cycles
+	row_lengths[rails - 1] = cycles
+
+	iter := RailIterator{
+		rails: rails
+		count: msg_length % period
+	}
+	for rail in iter {
+		row_lengths[rail]++
+	}
+
+	mut offsets := []int{len: rails}
+	mut acc := 0
+	for rail in 0 .. rails {
+		offsets[rail] = acc
+		acc += row_lengths[rail]
+	}
+	assert acc == msg_length
+	return offsets
+}
+
+fn encode(msg string, rails int) string {
+	mut offsets := row_offsets(msg.len, rails)
+	mut result := []u8{len: msg.len}
+
+	iter := RailIterator{
+		rails: rails
+		count: msg.len
+	}
+	mut index := 0
+	for rail in iter {
+		result[offsets[rail]] = msg[index]
+		offsets[rail]++
+		index++
+	}
+	return result.bytestr()
+}
+
+fn decode(msg string, rails int) string {
+	mut offsets := row_offsets(msg.len, rails)
+	mut result := []u8{len: msg.len}
+
+	iter := RailIterator{
+		rails: rails
+		count: msg.len
+	}
+	mut index := 0
+	for rail in iter {
+		result[index] = msg[offsets[rail]]
+		offsets[rail]++
+		index++
+	}
+	return result.bytestr()
+}

--- a/exercises/practice/rail-fence-cipher/.meta/tests.toml
+++ b/exercises/practice/rail-fence-cipher/.meta/tests.toml
@@ -1,0 +1,21 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[46dc5c50-5538-401d-93a5-41102680d068]
+description = "encode -> encode with two rails"
+
+[25691697-fbd8-4278-8c38-b84068b7bc29]
+description = "encode -> encode with three rails"
+
+[384f0fea-1442-4f1a-a7c4-5cbc2044002c]
+description = "encode -> encode with ending in the middle"
+
+[cd525b17-ec34-45ef-8f0e-4f27c24a7127]
+description = "decode -> decode with three rails"
+
+[dd7b4a98-1a52-4e5c-9499-cbb117833507]
+description = "decode -> decode with five rails"
+
+[93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3]
+description = "decode -> decode with six rails"

--- a/exercises/practice/rail-fence-cipher/rail-fence-cipher.v
+++ b/exercises/practice/rail-fence-cipher/rail-fence-cipher.v
@@ -1,0 +1,7 @@
+module main
+
+fn encode(msg string, rails int) string {
+}
+
+fn decode(msg string, rails int) string {
+}

--- a/exercises/practice/rail-fence-cipher/run_test.v
+++ b/exercises/practice/rail-fence-cipher/run_test.v
@@ -1,0 +1,37 @@
+module main
+
+fn test_encode_with_two_rails() {
+	message := 'XOXOXOXOXOXOXOXOXO'
+	encoded := 'XXXXXXXXXOOOOOOOOO'
+	assert encode(message, 2) == encoded
+}
+
+fn test_encode_with_three_rails() {
+	message := 'WEAREDISCOVEREDFLEEATONCE'
+	encoded := 'WECRLTEERDSOEEFEAOCAIVDEN'
+	assert encode(message, 3) == encoded
+}
+
+fn test_encode_with_ending_in_the_middle() {
+	message := 'EXERCISES'
+	encoded := 'ESXIEECSR'
+	assert encode(message, 4) == encoded
+}
+
+fn test_decode_with_three_rails() {
+	message := 'TEITELHDVLSNHDTISEIIEA'
+	decoded := 'THEDEVILISINTHEDETAILS'
+	assert decode(message, 3) == decoded
+}
+
+fn test_decode_with_five_rails() {
+	message := 'EIEXMSMESAORIWSCE'
+	decoded := 'EXERCISMISAWESOME'
+	assert decode(message, 5) == decoded
+}
+
+fn test_decode_with_six_rails() {
+	message := '133714114238148966225439541018335470986172518171757571896261'
+	decoded := '112358132134558914423337761098715972584418167651094617711286'
+	assert decode(message, 6) == decoded
+}


### PR DESCRIPTION
Function and argument names, and test cases, are taken from
https://github.com/exercism/problem-specifications/blob/main/exercises/rail-fence-cipher/canonical-data.json