### PR TITLE
feat: Add Affine Cipher (closes #114)

### DIFF
--- a/config.json
+++ b/config.json
@@ -346,6 +346,14 @@
         "difficulty": 6
       },
       {
+        "slug": "affine-cipher",
+        "name": "Affine Cipher",
+        "uuid": "80c52bdc-1d57-49b0-b72d-a890faf3c4b2",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4
+      },
+      {
         "slug": "connect",
         "name": "Connect",
         "uuid": "3bbc3fc9-2bbe-4eec-ac5f-8736a0bf257d",

--- a/exercises/practice/affine-cipher/.docs/instructions.md
+++ b/exercises/practice/affine-cipher/.docs/instructions.md
@@ -1,0 +1,74 @@
+# Instructions
+
+Create an implementation of the affine cipher, an ancient encryption system created in the Middle East.
+
+The affine cipher is a type of monoalphabetic substitution cipher.
+Each character is mapped to its numeric equivalent, encrypted with a mathematical function and then converted to the letter relating to its new numeric value.
+Although all monoalphabetic ciphers are weak, the affine cipher is much stronger than the atbash cipher, because it has many more keys.
+
+[//]: # ( monoalphabetic as spelled by Merriam-Webster, compare to polyalphabetic )
+
+## Encryption
+
+The encryption function is:
+
+```text
+E(x) = (ai + b) mod m
+```
+
+Where:
+
+- `i` is the letter's index from `0` to the length of the alphabet - 1
+- `m` is the length of the alphabet.
+  For the Roman alphabet `m` is `26`.
+- `a` and `b` are integers which make the encryption key
+
+Values `a` and `m` must be *coprime* (or, *relatively prime*) for automatic decryption to succeed, i.e., they have number `1` as their only common factor (more information can be found in the [Wikipedia article about coprime integers][coprime-integers]).
+In case `a` is not coprime to `m`, your program should indicate that this is an error.
+Otherwise it should encrypt or decrypt with the provided key.
+
+For the purpose of this exercise, digits are valid input but they are not encrypted.
+Spaces and punctuation characters are excluded.
+Ciphertext is written out in groups of fixed length separated by space, the traditional group size being `5` letters.
+This is to make it harder to guess encrypted text based on word boundaries.
+
+## Decryption
+
+The decryption function is:
+
+```text
+D(y) = (a^-1)(y - b) mod m
+```
+
+Where:
+
+- `y` is the numeric value of an encrypted letter, i.e., `y = E(x)`
+- it is important to note that `a^-1` is the modular multiplicative inverse (MMI) of `a mod m`
+- the modular multiplicative inverse only exists if `a` and `m` are coprime.
+
+The MMI of `a` is `x` such that the remainder after dividing `ax` by `m` is `1`:
+
+```text
+ax mod m = 1
+```
+
+More information regarding how to find a Modular Multiplicative Inverse and what it means can be found in the [related Wikipedia article][mmi].
+
+## General Examples
+
+- Encrypting `"test"` gives `"ybty"` with the key `a = 5`, `b = 7`
+- Decrypting `"ybty"` gives `"test"` with the key `a = 5`, `b = 7`
+- Decrypting `"ybty"` gives `"lqul"` with the wrong key `a = 11`, `b = 7`
+- Decrypting `"kqlfd jzvgy tpaet icdhm rtwly kqlon ubstx"` gives `"thequickbrownfoxjumpsoverthelazydog"` with the key `a = 19`, `b = 13`
+- Encrypting `"test"` with the key `a = 18`, `b = 13` is an error because `18` and `26` are not coprime
+
+## Example of finding a Modular Multiplicative Inverse (MMI)
+
+Finding MMI for `a = 15`:
+
+- `(15 * x) mod 26 = 1`
+- `(15 * 7) mod 26 = 1`, ie. `105 mod 26 = 1`
+- `7` is the MMI of `15 mod 26`
+
+[mmi]: https://en.wikipedia.org/wiki/Modular_multiplicative_inverse
+[coprime-integers]: https://en.wikipedia.org/wiki/Coprime_integers

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "affine-cipher.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ]
+  },
+  "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Affine_cipher"
+}

--- a/exercises/practice/affine-cipher/.meta/example.v
+++ b/exercises/practice/affine-cipher/.meta/example.v
@@ -1,0 +1,68 @@
+module main
+
+import math
+
+struct Key {
+	a int
+	b int
+}
+
+// Returns a non-negative value, even if a is negative.
+fn mod(a int, b int) int {
+	assert 0 < b
+	r := a % b
+	return if 0 <= r { r } else { b + r }
+}
+
+// modular multiplicative inverse
+fn mmi(a int, m int) int {
+	_, _, y := math.egcd(m, a)
+	return int(y)
+}
+
+fn encode(phrase string, key Key) !string {
+	if key.a == 0 || math.gcd(26, key.a) != 1 {
+		return error('a and m must be coprime.')
+	}
+	mut buffer := []u8{cap: phrase.len * 6 / 5}
+	for ch in phrase {
+		if !ch.is_alnum() {
+			continue
+		}
+		if buffer.len % 6 == 5 {
+			buffer << u8(` `)
+		}
+		if ch.is_digit() {
+			buffer << ch
+			continue
+		}
+		i := if ch >= `a` { int(ch - `a`) } else { int(ch - `A`) }
+		assert 0 <= i && i < 26
+		j := mod(key.a * i + key.b, 26)
+		buffer << u8(`a` + j)
+	}
+	return buffer.bytestr()
+}
+
+fn decode(phrase string, key Key) !string {
+	if key.a == 0 || math.gcd(26, key.a) != 1 {
+		return error('a and m must be coprime.')
+	}
+	a_inverse := mmi(key.a, 26)
+	assert mod(a_inverse * key.a, 26) == 1
+	mut buffer := []u8{cap: phrase.len}
+	for ch in phrase {
+		if !ch.is_alnum() {
+			continue
+		}
+		if ch.is_digit() {
+			buffer << ch
+			continue
+		}
+		j := int(ch - `a`)
+		assert 0 <= j && j < 26
+		i := mod(a_inverse * (j - key.b), 26)
+		buffer << u8(`a` + i)
+	}
+	return buffer.bytestr()
+}

--- a/exercises/practice/affine-cipher/.meta/tests.toml
+++ b/exercises/practice/affine-cipher/.meta/tests.toml
@@ -1,0 +1,51 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a]
+description = "encode -> encode yes"
+
+[785bade9-e98b-4d4f-a5b0-087ba3d7de4b]
+description = "encode -> encode no"
+
+[2854851c-48fb-40d8-9bf6-8f192ed25054]
+description = "encode -> encode OMG"
+
+[bc0c1244-b544-49dd-9777-13a770be1bad]
+description = "encode -> encode O M G"
+
+[381a1a20-b74a-46ce-9277-3778625c9e27]
+description = "encode -> encode mindblowingly"
+
+[6686f4e2-753b-47d4-9715-876fdc59029d]
+description = "encode -> encode numbers"
+
+[ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3]
+description = "encode -> encode deep thought"
+
+[c93a8a4d-426c-42ef-9610-76ded6f7ef57]
+description = "encode -> encode all the letters"
+
+[0673638a-4375-40bd-871c-fb6a2c28effb]
+description = "encode -> encode with a not coprime to m"
+
+[3f0ac7e2-ec0e-4a79-949e-95e414953438]
+description = "decode -> decode exercism"
+
+[241ee64d-5a47-4092-a5d7-7939d259e077]
+description = "decode -> decode a sentence"
+
+[33fb16a1-765a-496f-907f-12e644837f5e]
+description = "decode -> decode numbers"
+
+[20bc9dce-c5ec-4db6-a3f1-845c776bcbf7]
+description = "decode -> decode all the letters"
+
+[623e78c0-922d-49c5-8702-227a3e8eaf81]
+description = "decode -> decode with no spaces in input"
+
+[58fd5c2a-1fd9-4563-a80a-71cff200f26f]
+description = "decode -> decode with too many spaces"
+
+[b004626f-c186-4af9-a3f4-58f74cdb86d5]
+description = "decode -> decode with a not coprime to m"

--- a/exercises/practice/affine-cipher/affine-cipher.v
+++ b/exercises/practice/affine-cipher/affine-cipher.v
@@ -1,0 +1,12 @@
+module main
+
+struct Key {
+	a int
+	b int
+}
+
+fn encode(phrase string, key Key) !string {
+}
+
+fn decode(phrase string, key Key) !string {
+}

--- a/exercises/practice/affine-cipher/run_test.v
+++ b/exercises/practice/affine-cipher/run_test.v
@@ -1,0 +1,103 @@
+module main
+
+fn test_encode_yes() {
+	phrase := 'yes'
+	expect := 'xbt'
+	assert encode(phrase, Key{ a: 5, b: 7 })! == expect
+}
+
+fn test_encode_no() {
+	phrase := 'no'
+	expect := 'fu'
+	assert encode(phrase, Key{ a: 15, b: 18 })! == expect
+}
+
+fn test_encode_omg() {
+	phrase := 'OMG'
+	expect := 'lvz'
+	assert encode(phrase, Key{ a: 21, b: 3 })! == expect
+}
+
+fn test_encode_o_m_g() {
+	phrase := 'O M G'
+	expect := 'hjp'
+	assert encode(phrase, Key{ a: 25, b: 47 })! == expect
+}
+
+fn test_encode_mindblowingly() {
+	phrase := 'mindblowingly'
+	expect := 'rzcwa gnxzc dgt'
+	assert encode(phrase, Key{ a: 11, b: 15 })! == expect
+}
+
+fn test_encode_numbers() {
+	phrase := 'Testing,1 2 3, testing.'
+	expect := 'jqgjc rw123 jqgjc rw'
+	assert encode(phrase, Key{ a: 3, b: 4 })! == expect
+}
+
+fn test_encode_deep_thought() {
+	phrase := 'Truth is fiction.'
+	expect := 'iynia fdqfb ifje'
+	assert encode(phrase, Key{ a: 5, b: 17 })! == expect
+}
+
+fn test_encode_all_the_letters() {
+	phrase := 'The quick brown fox jumps over the lazy dog.'
+	expect := 'swxtj npvyk lruol iejdc blaxk swxmh qzglf'
+	assert encode(phrase, Key{ a: 17, b: 33 })! == expect
+}
+
+fn test_encode_with_a_not_coprime_to_m() {
+	phrase := 'This is a test.'
+	if res := encode(phrase, Key{ a: 6, b: 17 }) {
+		assert false, 'encode with a not coprime to m should return an error'
+	} else {
+		assert typeof(err).name == 'IError'
+	}
+}
+
+fn test_decode_exercism() {
+	phrase := 'tytgn fjr'
+	expect := 'exercism'
+	assert decode(phrase, Key{ a: 3, b: 7 })! == expect
+}
+
+fn test_decode_a_sentence() {
+	phrase := 'qdwju nqcro muwhn odqun oppmd aunwd o'
+	expect := 'anobstacleisoftenasteppingstone'
+	assert decode(phrase, Key{ a: 19, b: 16 })! == expect
+}
+
+fn test_decode_numbers() {
+	phrase := 'odpoz ub123 odpoz ub'
+	expect := 'testing123testing'
+	assert decode(phrase, Key{ a: 25, b: 7 })! == expect
+}
+
+fn test_decode_all_the_letters() {
+	phrase := 'swxtj npvyk lruol iejdc blaxk swxmh qzglf'
+	expect := 'thequickbrownfoxjumpsoverthelazydog'
+	assert decode(phrase, Key{ a: 17, b: 33 })! == expect
+}
+
+fn test_decode_with_no_spaces_in_input() {
+	phrase := 'swxtjnpvyklruoliejdcblaxkswxmhqzglf'
+	expect := 'thequickbrownfoxjumpsoverthelazydog'
+	assert decode(phrase, Key{ a: 17, b: 33 })! == expect
+}
+
+fn test_decode_with_too_many_spaces() {
+	phrase := 'vszzm    cly   yd cg    qdp'
+	expect := 'jollygreengiant'
+	assert decode(phrase, Key{ a: 15, b: 16 })! == expect
+}
+
+fn test_decode_with_a_not_coprime_to_m() {
+	phrase := 'Test'
+	if res := decode(phrase, Key{ a: 13, b: 5 }) {
+		assert false, 'decode with a not coprime to m should return an error'
+	} else {
+		assert typeof(err).name == 'IError'
+	}
+}


### PR DESCRIPTION
Function and argument names, and test cases, are taken from
https://github.com/exercism/problem-specifications/blob/main/exercises/affine-cipher/canonical-data.json

closes #114