### PR TITLE
feat: Add Two Bucket (closes #98)

### DIFF
--- a/config.json
+++ b/config.json
@@ -322,6 +322,14 @@
         "difficulty": 3
       },
       {
+        "slug": "two-bucket",
+        "name": "Two Bucket",
+        "uuid": "8793305d-820f-4ae6-92e0-43cb6d9cfbd8",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
         "slug": "change",
         "name": "Change",
         "uuid": "6a8d5dd8-a7f0-453b-97cd-a12e505cac32",

--- a/exercises/practice/two-bucket/.docs/instructions.md
+++ b/exercises/practice/two-bucket/.docs/instructions.md
@@ -1,0 +1,46 @@
+# Instructions
+
+Given two buckets of different size and which bucket to fill first, determine how many actions are required to measure an exact number of liters by strategically transferring fluid between the buckets.
+
+There are some rules that your solution must follow:
+
+- You can only do one action at a time.
+- There are only 3 possible actions:
+  1. Pouring one bucket into the other bucket until either:
+     a) the first bucket is empty
+     b) the second bucket is full
+  2. Emptying a bucket and doing nothing to the other.
+  3. Filling a bucket and doing nothing to the other.
+- After an action, you may not arrive at a state where the starting bucket is empty and the other bucket is full.
+
+Your program will take as input:
+
+- the size of bucket one
+- the size of bucket two
+- the desired number of liters to reach
+- which bucket to fill first, either bucket one or bucket two
+
+Your program should determine:
+
+- the total number of actions it should take to reach the desired number of liters, including the first fill of the starting bucket
+- which bucket should end up with the desired number of liters - either bucket one or bucket two
+- how many liters are left in the other bucket
+
+Note: any time a change is made to either or both buckets counts as one (1) action.
+
+Example:
+Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters.
+Let's say at a given step, bucket one is holding 7 liters and bucket two is holding 8 liters (7,8).
+If you empty bucket one and make no change to bucket two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as one action.
+Instead, if you had poured from bucket one into bucket two until bucket two was full, resulting in 4 liters in bucket one and 11 liters in bucket two (4,11), that would also only count as one action.
+
+Another Example:
+Bucket one can hold 3 liters, and bucket two can hold up to 5 liters.
+You are told you must start with bucket one.
+So your first action is to fill bucket one.
+You choose to empty bucket one for your second action.
+For your third action, you may not fill bucket two, because this violates the third rule -- you may not end up in a state after any action where the starting bucket is empty and the other bucket is full.
+
+Written with <3 at [Fullstack Academy][fullstack] by Lindsay Levine.
+
+[fullstack]: https://www.fullstackacademy.com/

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "two-bucket.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ]
+  },
+  "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
+  "source": "Water Pouring Problem",
+  "source_url": "https://demonstrations.wolfram.com/WaterPouringProblem/"
+}

--- a/exercises/practice/two-bucket/.meta/example.v
+++ b/exercises/practice/two-bucket/.meta/example.v
@@ -1,0 +1,147 @@
+module main
+
+enum BucketId {
+	one
+	two
+}
+
+struct Solution {
+	moves        int
+	goal_bucket  BucketId
+	other_bucket int
+}
+
+struct State {
+	contents_one int
+	contents_two int
+}
+
+struct Search {
+	capacity_one int
+	capacity_two int
+mut:
+	seen  []bool
+	queue []State
+}
+
+fn (search Search) id_for_state(contents_one int, contents_two int) int {
+	capacity_one := search.capacity_one
+	capacity_two := search.capacity_two
+	combined_capacity := capacity_one + capacity_two
+
+	// After each move, at least one bucket is either empty or full.
+	// We enumerate the valid states as follows:
+	// States 0..capacity_two: bucket one empty, contents_two increasing.
+	// States capacity_two..combined_capacity: contents_one increasing, bucket two full.
+	// States combined_capacity..(combined_capacity + capacity_two): bucket one full, contents_two decreasing.
+	// States (combined_capacity + capacity_two)..(2 * combined_capacity): contents_one decreasing, bucket two empty.
+
+	if contents_one == 0 {
+		return contents_two
+	}
+	if contents_two == capacity_two {
+		return capacity_two + contents_one
+	}
+	if contents_one == capacity_one {
+		return capacity_one + 2 * capacity_two - contents_two
+	}
+	if contents_two == 0 {
+		return 2 * (capacity_one + capacity_two) - contents_one
+	}
+	panic('invalid state')
+}
+
+fn (mut search Search) exclude(contents_one int, contents_two int) {
+	id := search.id_for_state(contents_one, contents_two)
+	search.seen[id] = true
+}
+
+fn (mut search Search) enqueue(contents_one int, contents_two int) {
+	id := search.id_for_state(contents_one, contents_two)
+	if search.seen[id] {
+		return
+	}
+	search.queue << State{
+		contents_one: contents_one
+		contents_two: contents_two
+	}
+	search.seen[id] = true
+}
+
+fn new_search(capacity_one int, capacity_two int) Search {
+	mut result := Search{
+		capacity_one: capacity_one
+		capacity_two: capacity_two
+	}
+	result.seen = []bool{len: 2 * (capacity_one + capacity_two), init: false}
+	result.queue = []State{cap: 2 * (capacity_one + capacity_two)}
+	return result
+}
+
+pub fn measure(capacity_one int, capacity_two int, goal int, start_bucket BucketId) !Solution {
+	assert goal != 0
+
+	mut search := new_search(capacity_one, capacity_two)
+	if start_bucket == .one {
+		search.enqueue(capacity_one, 0)
+		search.exclude(0, capacity_two)
+	} else {
+		search.enqueue(0, capacity_two)
+		search.exclude(capacity_one, 0)
+	}
+
+	mut moves := 1
+	// The total number of states added before the next move.
+	mut old_back := search.queue.len
+
+	mut front := 0
+	for front < search.queue.len {
+		contents_one := search.queue[front].contents_one
+		contents_two := search.queue[front].contents_two
+		combined_contents := contents_one + contents_two
+
+		if contents_one == goal {
+			return Solution{
+				moves: moves
+				goal_bucket: .one
+				other_bucket: contents_two
+			}
+		}
+		if contents_two == goal {
+			return Solution{
+				moves: moves
+				goal_bucket: .two
+				other_bucket: contents_one
+			}
+		}
+
+		// Pouring one bucket into the other bucket.
+		if combined_contents <= capacity_one {
+			search.enqueue(combined_contents, 0)
+		} else {
+			search.enqueue(capacity_one, combined_contents - capacity_one)
+		}
+		if combined_contents <= capacity_two {
+			search.enqueue(0, combined_contents)
+		} else {
+			search.enqueue(combined_contents - capacity_two, capacity_two)
+		}
+
+		// Emptying a bucket and doing nothing to the other.
+		search.enqueue(0, contents_two)
+		search.enqueue(contents_one, 0)
+
+		// Filling a bucket and doing nothing to the other.
+		search.enqueue(capacity_one, contents_two)
+		search.enqueue(contents_one, capacity_two)
+
+		front += 1
+		if front == old_back {
+			moves += 1
+			old_back = search.queue.len
+		}
+	}
+
+	// No more reachable states.
+	return error('impossible')
+}

--- a/exercises/practice/two-bucket/.meta/tests.toml
+++ b/exercises/practice/two-bucket/.meta/tests.toml
@@ -1,0 +1,30 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[a6f2b4ba-065f-4dca-b6f0-e3eee51cb661]
+description = "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one"
+
+[6c4ea451-9678-4926-b9b3-68364e066d40]
+description = "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two"
+
+[3389f45e-6a56-46d5-9607-75aa930502ff]
+description = "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one"
+
+[fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1]
+description = "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two"
+
+[0ee1f57e-da84-44f7-ac91-38b878691602]
+description = "Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two"
+
+[eb329c63-5540-4735-b30b-97f7f4df0f84]
+description = "Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two"
+
+[449be72d-b10a-4f4b-a959-ca741e333b72]
+description = "Not possible to reach the goal"
+
+[aac38b7a-77f4-4d62-9b91-8846d533b054]
+description = "With the same buckets but a different goal, then it is possible"
+
+[74633132-0ccf-49de-8450-af4ab2e3b299]
+description = "Goal larger than both buckets is impossible"

--- a/exercises/practice/two-bucket/run_test.v
+++ b/exercises/practice/two-bucket/run_test.v
@@ -1,0 +1,80 @@
+module main
+
+fn test_measure_using_bucket_one_of_size_3_and_bucket_two_of_size_5___start_with_bucket_one() {
+	expected := Solution{
+		moves: 4
+		goal_bucket: BucketId.one
+		other_bucket: 5
+	}
+	assert measure(3, 5, 1, BucketId.one)! == expected
+}
+
+fn test_measure_using_bucket_one_of_size_3_and_bucket_two_of_size_5___start_with_bucket_two() {
+	expected := Solution{
+		moves: 8
+		goal_bucket: BucketId.two
+		other_bucket: 3
+	}
+	assert measure(3, 5, 1, BucketId.two)! == expected
+}
+
+fn test_measure_using_bucket_one_of_size_7_and_bucket_two_of_size_11___start_with_bucket_one() {
+	expected := Solution{
+		moves: 14
+		goal_bucket: BucketId.one
+		other_bucket: 11
+	}
+	assert measure(7, 11, 2, BucketId.one)! == expected
+}
+
+fn test_measure_using_bucket_one_of_size_7_and_bucket_two_of_size_11___start_with_bucket_two() {
+	expected := Solution{
+		moves: 18
+		goal_bucket: BucketId.two
+		other_bucket: 7
+	}
+	assert measure(7, 11, 2, BucketId.two)! == expected
+}
+
+fn test_measure_one_step_using_bucket_one_of_size_1_and_bucket_two_of_size_3___start_with_bucket_two() {
+	expected := Solution{
+		moves: 1
+		goal_bucket: BucketId.two
+		other_bucket: 0
+	}
+	assert measure(1, 3, 3, BucketId.two)! == expected
+}
+
+fn test_measure_using_bucket_one_of_size_2_and_bucket_two_of_size_3___start_with_bucket_one_and_end_with_bucket_two() {
+	expected := Solution{
+		moves: 2
+		goal_bucket: BucketId.two
+		other_bucket: 2
+	}
+	assert measure(2, 3, 3, BucketId.one)! == expected
+}
+
+fn test_not_possible_to_reach_the_goal() {
+	if res := measure(6, 15, 5, BucketId.one) {
+		assert false, 'Not possible to reach the goal should return an error'
+	} else {
+		assert err.msg() == 'impossible'
+	}
+}
+
+fn test_with_the_same_buckets_but_a_different_goal_then_it_is_possible() {
+	expected := Solution{
+		moves: 10
+		goal_bucket: BucketId.two
+		other_bucket: 0
+	}
+	assert measure(6, 15, 9, BucketId.one)! == expected
+}
+
+fn test_goal_larger_than_both_buckets_is_impossible() {
+	if res := measure(5, 7, 8, BucketId.one) {
+		assert false, 'Goal larger than both buckets impossible should return an error'
+	} else {
+		assert err.msg() == 'impossible'
+	}
+}

--- a/exercises/practice/two-bucket/two-bucket.v
+++ b/exercises/practice/two-bucket/two-bucket.v
@@ -1,0 +1,15 @@
+module main
+
+enum BucketId {
+	one
+	two
+}
+
+struct Solution {
+	moves        int
+	goal_bucket  BucketId
+	other_bucket int
+}
+
+pub fn measure(capacity_one int, capacity_two int, goal int, start_bucket BucketId) !Solution {
+}


### PR DESCRIPTION
Changes from [canonical-data.json](https://github.com/exercism/problem-specifications/blob/main/exercises/two-bucket/canonical-data.json):

- To identify the buckets, we use an enum instead of strings.

- The first two `measure` arguments are renamed from `bucketOne` and `bucketTwo` to `capacity_one` and `capacity_two`
