### PR TITLE
Add Word Search practice exercise (closes #124)

### DIFF
--- a/config.json
+++ b/config.json
@@ -370,6 +370,14 @@
         "difficulty": 2
       },
       {
+        "slug": "word-search",
+        "name": "Word Search",
+        "uuid": "d805019c-2497-4dae-84c6-1123fc6cb1e2",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 7
+      },
+      {
         "slug": "simple-linked-list",
         "name": "Simple Linked List",
         "uuid": "42b638fb-3ad1-4a0f-a26b-096ad583c997",

--- a/exercises/practice/word-search/.docs/instructions.md
+++ b/exercises/practice/word-search/.docs/instructions.md
@@ -1,0 +1,24 @@
+# Instructions
+
+In word search puzzles you get a square of letters and have to find specific words in them.
+
+For example:
+
+```text
+jefblpepre
+camdcimgtc
+oivokprjsm
+pbwasqroua
+rixilelhrs
+wolcqlirpc
+screeaumgr
+alxhpburyi
+jalaycalmp
+clojurermt
+```
+
+There are several programming languages hidden in the above square.
+
+Words can be hidden in all kinds of directions: left-to-right, right-to-left, vertical and diagonal.
+
+Given a puzzle and a list of words return the location of the first and last letter of each word.

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "word-search.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ]
+  },
+  "blurb": "Create a program to solve a word search puzzle."
+}

--- a/exercises/practice/word-search/.meta/example.v
+++ b/exercises/practice/word-search/.meta/example.v
@@ -1,0 +1,55 @@
+module main
+
+// Grid rows and columns are 1-indexed.
+struct Pair {
+	column int
+	row    int
+}
+
+struct WordLocation {
+	start Pair
+	end   Pair
+}
+
+fn search(grid []string, words_to_search_for []string) map[string]?WordLocation {
+	mut result := map[string]?WordLocation{}
+	rows := grid.len
+	columns := if rows == 0 { 0 } else { grid[0].len }
+	for word in words_to_search_for {
+		last_char_index := word.len - 1
+		mut word_result := ?WordLocation(none)
+		for delta_row in -1 .. 2 {
+			begin_row := if delta_row < 0 { last_char_index } else { 0 }
+			end_row := if delta_row <= 0 { rows } else { rows - last_char_index }
+			for delta_column in -1 .. 2 {
+				if delta_row == 0 && delta_column == 0 {
+					continue
+				}
+				begin_column := if delta_column < 0 { last_char_index } else { 0 }
+				end_column := if delta_column <= 0 { columns } else { columns - last_char_index }
+
+				for row in begin_row .. end_row {
+					scan: for column in begin_column .. end_column {
+						for i in 0 .. word.len {
+							if grid[row + i * delta_row][column + i * delta_column] != word[i] {
+								continue scan
+							}
+						}
+						word_result = ?WordLocation{
+							start: Pair{
+								column: column + 1
+								row: row + 1
+							}
+							end: Pair{
+								column: column + 1 + last_char_index * delta_column
+								row: row + 1 + last_char_index * delta_row
+							}
+						}
+					}
+				}
+			}
+		}
+		result[word] = word_result
+	}
+	return result
+}

--- a/exercises/practice/word-search/.meta/tests.toml
+++ b/exercises/practice/word-search/.meta/tests.toml
@@ -1,0 +1,75 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[b4057815-0d01-41f0-9119-6a91f54b2a0a]
+description = "Should accept an initial game grid and a target search word"
+
+[6b22bcc5-6cbf-4674-931b-d2edbff73132]
+description = "Should locate one word written left to right"
+
+[ff462410-434b-442d-9bc3-3360c75f34a8]
+description = "Should locate the same word written left to right in a different position"
+
+[a02febae-6347-443e-b99c-ab0afb0b8fca]
+description = "Should locate a different left to right word"
+
+[e42e9987-6304-4e13-8232-fa07d5280130]
+description = "Should locate that different left to right word in a different position"
+
+[9bff3cee-49b9-4775-bdfb-d55b43a70b2f]
+description = "Should locate a left to right word in two line grid"
+
+[851a35fb-f499-4ec1-9581-395a87903a22]
+description = "Should locate a left to right word in three line grid"
+
+[2f3dcf84-ba7d-4b75-8b8d-a3672b32c035]
+description = "Should locate a left to right word in ten line grid"
+
+[006d4856-f365-4e84-a18c-7d129ce9eefb]
+description = "Should locate that left to right word in a different position in a ten line grid"
+
+[eff7ac9f-ff11-443e-9747-40850c12ab60]
+description = "Should locate a different left to right word in a ten line grid"
+
+[dea39f86-8c67-4164-8884-13bfc48bd13b]
+description = "Should locate multiple words"
+
+[29e6a6a5-f80c-48a6-8e68-05bbbe187a09]
+description = "Should locate a single word written right to left"
+
+[3cf34428-b43f-48b6-b332-ea0b8836011d]
+description = "Should locate multiple words written in different horizontal directions"
+
+[2c8cd344-a02f-464b-93b6-8bf1bd890003]
+description = "Should locate words written top to bottom"
+
+[9ee1e43d-e59d-4c32-9a5f-6a22d4a1550f]
+description = "Should locate words written bottom to top"
+
+[6a21a676-f59e-4238-8e88-9f81015afae9]
+description = "Should locate words written top left to bottom right"
+
+[c9125189-1861-4b0d-a14e-ba5dab29ca7c]
+description = "Should locate words written bottom right to top left"
+
+[b19e2149-7fc5-41ec-a8a9-9bc6c6c38c40]
+description = "Should locate words written bottom left to top right"
+
+[69e1d994-a6d7-4e24-9b5a-db76751c2ef8]
+description = "Should locate words written top right to bottom left"
+
+[695531db-69eb-463f-8bad-8de3bf5ef198]
+description = "Should fail to locate a word that is not in the puzzle"
+
+[fda5b937-6774-4a52-8f89-f64ed833b175]
+description = "Should fail to locate words that are not on horizontal, vertical, or diagonal lines"
+
+[5b6198eb-2847-4e2f-8efe-65045df16bd3]
+description = "Should not concatenate different lines to find a horizontal word"
+
+[eba44139-a34f-4a92-98e1-bd5f259e5769]
+description = "Should not wrap around horizontally to find a word"
+
+[cd1f0fa8-76af-4167-b105-935f78364dac]
+description = "Should not wrap around vertically to find a word"

--- a/exercises/practice/word-search/run_test.v
+++ b/exercises/practice/word-search/run_test.v
@@ -1,0 +1,1007 @@
+module main
+
+fn test_should_accept_an_initial_game_grid_and_a_target_search_word() {
+	grid := [
+		'jefblpepre',
+	]
+	words_to_search_for := [
+		'clojure',
+	]
+	expected := {
+		'clojure': ?WordLocation(none)
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_one_word_written_left_to_right() {
+	grid := [
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'clojure',
+	]
+	expected := {
+		'clojure': ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 1
+			}
+			end: Pair{
+				column: 7
+				row: 1
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_the_same_word_written_left_to_right_in_a_different_position() {
+	grid := [
+		'mtclojurer',
+	]
+	words_to_search_for := [
+		'clojure',
+	]
+	expected := {
+		'clojure': ?WordLocation{
+			start: Pair{
+				column: 3
+				row: 1
+			}
+			end: Pair{
+				column: 9
+				row: 1
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_a_different_left_to_right_word() {
+	grid := [
+		'coffeelplx',
+	]
+	words_to_search_for := [
+		'coffee',
+	]
+	expected := {
+		'coffee': ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 1
+			}
+			end: Pair{
+				column: 6
+				row: 1
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_that_different_left_to_right_word_in_a_different_position() {
+	grid := [
+		'xcoffeezlp',
+	]
+	words_to_search_for := [
+		'coffee',
+	]
+	expected := {
+		'coffee': ?WordLocation{
+			start: Pair{
+				column: 2
+				row: 1
+			}
+			end: Pair{
+				column: 7
+				row: 1
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_a_left_to_right_word_in_two_line_grid() {
+	grid := [
+		'jefblpepre',
+		'tclojurerm',
+	]
+	words_to_search_for := [
+		'clojure',
+	]
+	expected := {
+		'clojure': ?WordLocation{
+			start: Pair{
+				column: 2
+				row: 2
+			}
+			end: Pair{
+				column: 8
+				row: 2
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_a_left_to_right_word_in_three_line_grid() {
+	grid := [
+		'camdcimgtc',
+		'jefblpepre',
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'clojure',
+	]
+	expected := {
+		'clojure': ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 3
+			}
+			end: Pair{
+				column: 7
+				row: 3
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_a_left_to_right_word_in_ten_line_grid() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'screeaumgr',
+		'alxhpburyi',
+		'jalaycalmp',
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'clojure',
+	]
+	expected := {
+		'clojure': ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 10
+			}
+			end: Pair{
+				column: 7
+				row: 10
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_that_left_to_right_word_in_a_different_position_in_a_ten_line_grid() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'screeaumgr',
+		'alxhpburyi',
+		'clojurermt',
+		'jalaycalmp',
+	]
+	words_to_search_for := [
+		'clojure',
+	]
+	expected := {
+		'clojure': ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 9
+			}
+			end: Pair{
+				column: 7
+				row: 9
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_a_different_left_to_right_word_in_a_ten_line_grid() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'fortranftw',
+		'alxhpburyi',
+		'clojurermt',
+		'jalaycalmp',
+	]
+	words_to_search_for := [
+		'fortran',
+	]
+	expected := {
+		'fortran': ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 7
+			}
+			end: Pair{
+				column: 7
+				row: 7
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_multiple_words() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'fortranftw',
+		'alxhpburyi',
+		'jalaycalmp',
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'fortran',
+		'clojure',
+	]
+	expected := {
+		'clojure': ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 10
+			}
+			end: Pair{
+				column: 7
+				row: 10
+			}
+		}
+		'fortran': ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 7
+			}
+			end: Pair{
+				column: 7
+				row: 7
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_a_single_word_written_right_to_left() {
+	grid := [
+		'rixilelhrs',
+	]
+	words_to_search_for := [
+		'elixir',
+	]
+	expected := {
+		'elixir': ?WordLocation{
+			start: Pair{
+				column: 6
+				row: 1
+			}
+			end: Pair{
+				column: 1
+				row: 1
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_multiple_words_written_in_different_horizontal_directions() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'screeaumgr',
+		'alxhpburyi',
+		'jalaycalmp',
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'elixir',
+		'clojure',
+	]
+	expected := {
+		'clojure': ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 10
+			}
+			end: Pair{
+				column: 7
+				row: 10
+			}
+		}
+		'elixir':  ?WordLocation{
+			start: Pair{
+				column: 6
+				row: 5
+			}
+			end: Pair{
+				column: 1
+				row: 5
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_words_written_top_to_bottom() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'screeaumgr',
+		'alxhpburyi',
+		'jalaycalmp',
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'clojure',
+		'elixir',
+		'ecmascript',
+	]
+	expected := {
+		'clojure':    ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 10
+			}
+			end: Pair{
+				column: 7
+				row: 10
+			}
+		}
+		'elixir':     ?WordLocation{
+			start: Pair{
+				column: 6
+				row: 5
+			}
+			end: Pair{
+				column: 1
+				row: 5
+			}
+		}
+		'ecmascript': ?WordLocation{
+			start: Pair{
+				column: 10
+				row: 1
+			}
+			end: Pair{
+				column: 10
+				row: 10
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_words_written_bottom_to_top() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'screeaumgr',
+		'alxhpburyi',
+		'jalaycalmp',
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'clojure',
+		'elixir',
+		'ecmascript',
+		'rust',
+	]
+	expected := {
+		'clojure':    ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 10
+			}
+			end: Pair{
+				column: 7
+				row: 10
+			}
+		}
+		'elixir':     ?WordLocation{
+			start: Pair{
+				column: 6
+				row: 5
+			}
+			end: Pair{
+				column: 1
+				row: 5
+			}
+		}
+		'ecmascript': ?WordLocation{
+			start: Pair{
+				column: 10
+				row: 1
+			}
+			end: Pair{
+				column: 10
+				row: 10
+			}
+		}
+		'rust':       ?WordLocation{
+			start: Pair{
+				column: 9
+				row: 5
+			}
+			end: Pair{
+				column: 9
+				row: 2
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_words_written_top_left_to_bottom_right() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'screeaumgr',
+		'alxhpburyi',
+		'jalaycalmp',
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'clojure',
+		'elixir',
+		'ecmascript',
+		'rust',
+		'java',
+	]
+	expected := {
+		'clojure':    ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 10
+			}
+			end: Pair{
+				column: 7
+				row: 10
+			}
+		}
+		'elixir':     ?WordLocation{
+			start: Pair{
+				column: 6
+				row: 5
+			}
+			end: Pair{
+				column: 1
+				row: 5
+			}
+		}
+		'ecmascript': ?WordLocation{
+			start: Pair{
+				column: 10
+				row: 1
+			}
+			end: Pair{
+				column: 10
+				row: 10
+			}
+		}
+		'rust':       ?WordLocation{
+			start: Pair{
+				column: 9
+				row: 5
+			}
+			end: Pair{
+				column: 9
+				row: 2
+			}
+		}
+		'java':       ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 1
+			}
+			end: Pair{
+				column: 4
+				row: 4
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_words_written_bottom_right_to_top_left() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'screeaumgr',
+		'alxhpburyi',
+		'jalaycalmp',
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'clojure',
+		'elixir',
+		'ecmascript',
+		'rust',
+		'java',
+		'lua',
+	]
+	expected := {
+		'clojure':    ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 10
+			}
+			end: Pair{
+				column: 7
+				row: 10
+			}
+		}
+		'elixir':     ?WordLocation{
+			start: Pair{
+				column: 6
+				row: 5
+			}
+			end: Pair{
+				column: 1
+				row: 5
+			}
+		}
+		'ecmascript': ?WordLocation{
+			start: Pair{
+				column: 10
+				row: 1
+			}
+			end: Pair{
+				column: 10
+				row: 10
+			}
+		}
+		'rust':       ?WordLocation{
+			start: Pair{
+				column: 9
+				row: 5
+			}
+			end: Pair{
+				column: 9
+				row: 2
+			}
+		}
+		'java':       ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 1
+			}
+			end: Pair{
+				column: 4
+				row: 4
+			}
+		}
+		'lua':        ?WordLocation{
+			start: Pair{
+				column: 8
+				row: 9
+			}
+			end: Pair{
+				column: 6
+				row: 7
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_words_written_bottom_left_to_top_right() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'screeaumgr',
+		'alxhpburyi',
+		'jalaycalmp',
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'clojure',
+		'elixir',
+		'ecmascript',
+		'rust',
+		'java',
+		'lua',
+		'lisp',
+	]
+	expected := {
+		'clojure':    ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 10
+			}
+			end: Pair{
+				column: 7
+				row: 10
+			}
+		}
+		'elixir':     ?WordLocation{
+			start: Pair{
+				column: 6
+				row: 5
+			}
+			end: Pair{
+				column: 1
+				row: 5
+			}
+		}
+		'ecmascript': ?WordLocation{
+			start: Pair{
+				column: 10
+				row: 1
+			}
+			end: Pair{
+				column: 10
+				row: 10
+			}
+		}
+		'rust':       ?WordLocation{
+			start: Pair{
+				column: 9
+				row: 5
+			}
+			end: Pair{
+				column: 9
+				row: 2
+			}
+		}
+		'java':       ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 1
+			}
+			end: Pair{
+				column: 4
+				row: 4
+			}
+		}
+		'lua':        ?WordLocation{
+			start: Pair{
+				column: 8
+				row: 9
+			}
+			end: Pair{
+				column: 6
+				row: 7
+			}
+		}
+		'lisp':       ?WordLocation{
+			start: Pair{
+				column: 3
+				row: 6
+			}
+			end: Pair{
+				column: 6
+				row: 3
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_locate_words_written_top_right_to_bottom_left() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'screeaumgr',
+		'alxhpburyi',
+		'jalaycalmp',
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'clojure',
+		'elixir',
+		'ecmascript',
+		'rust',
+		'java',
+		'lua',
+		'lisp',
+		'ruby',
+	]
+	expected := {
+		'clojure':    ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 10
+			}
+			end: Pair{
+				column: 7
+				row: 10
+			}
+		}
+		'elixir':     ?WordLocation{
+			start: Pair{
+				column: 6
+				row: 5
+			}
+			end: Pair{
+				column: 1
+				row: 5
+			}
+		}
+		'ecmascript': ?WordLocation{
+			start: Pair{
+				column: 10
+				row: 1
+			}
+			end: Pair{
+				column: 10
+				row: 10
+			}
+		}
+		'rust':       ?WordLocation{
+			start: Pair{
+				column: 9
+				row: 5
+			}
+			end: Pair{
+				column: 9
+				row: 2
+			}
+		}
+		'java':       ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 1
+			}
+			end: Pair{
+				column: 4
+				row: 4
+			}
+		}
+		'lua':        ?WordLocation{
+			start: Pair{
+				column: 8
+				row: 9
+			}
+			end: Pair{
+				column: 6
+				row: 7
+			}
+		}
+		'lisp':       ?WordLocation{
+			start: Pair{
+				column: 3
+				row: 6
+			}
+			end: Pair{
+				column: 6
+				row: 3
+			}
+		}
+		'ruby':       ?WordLocation{
+			start: Pair{
+				column: 8
+				row: 6
+			}
+			end: Pair{
+				column: 5
+				row: 9
+			}
+		}
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_fail_to_locate_a_word_that_is_not_in_the_puzzle() {
+	grid := [
+		'jefblpepre',
+		'camdcimgtc',
+		'oivokprjsm',
+		'pbwasqroua',
+		'rixilelhrs',
+		'wolcqlirpc',
+		'screeaumgr',
+		'alxhpburyi',
+		'jalaycalmp',
+		'clojurermt',
+	]
+	words_to_search_for := [
+		'clojure',
+		'elixir',
+		'ecmascript',
+		'rust',
+		'java',
+		'lua',
+		'lisp',
+		'ruby',
+		'haskell',
+	]
+	expected := {
+		'clojure':    ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 10
+			}
+			end: Pair{
+				column: 7
+				row: 10
+			}
+		}
+		'elixir':     ?WordLocation{
+			start: Pair{
+				column: 6
+				row: 5
+			}
+			end: Pair{
+				column: 1
+				row: 5
+			}
+		}
+		'ecmascript': ?WordLocation{
+			start: Pair{
+				column: 10
+				row: 1
+			}
+			end: Pair{
+				column: 10
+				row: 10
+			}
+		}
+		'rust':       ?WordLocation{
+			start: Pair{
+				column: 9
+				row: 5
+			}
+			end: Pair{
+				column: 9
+				row: 2
+			}
+		}
+		'java':       ?WordLocation{
+			start: Pair{
+				column: 1
+				row: 1
+			}
+			end: Pair{
+				column: 4
+				row: 4
+			}
+		}
+		'lua':        ?WordLocation{
+			start: Pair{
+				column: 8
+				row: 9
+			}
+			end: Pair{
+				column: 6
+				row: 7
+			}
+		}
+		'lisp':       ?WordLocation{
+			start: Pair{
+				column: 3
+				row: 6
+			}
+			end: Pair{
+				column: 6
+				row: 3
+			}
+		}
+		'ruby':       ?WordLocation{
+			start: Pair{
+				column: 8
+				row: 6
+			}
+			end: Pair{
+				column: 5
+				row: 9
+			}
+		}
+		'haskell':    ?WordLocation(none)
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_fail_to_locate_words_that_are_not_on_horizontal_vertical_or_diagonal_lines() {
+	grid := [
+		'abc',
+		'def',
+	]
+	words_to_search_for := [
+		'aef',
+		'ced',
+		'abf',
+		'cbd',
+	]
+	expected := {
+		'aef': ?WordLocation(none)
+		'ced': ?WordLocation(none)
+		'abf': ?WordLocation(none)
+		'cbd': ?WordLocation(none)
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_not_concatenate_different_lines_to_find_a_horizontal_word() {
+	grid := [
+		'abceli',
+		'xirdfg',
+	]
+	words_to_search_for := [
+		'elixir',
+	]
+	expected := {
+		'elixir': ?WordLocation(none)
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_not_wrap_around_horizontally_to_find_a_word() {
+	grid := [
+		'silabcdefp',
+	]
+	words_to_search_for := [
+		'lisp',
+	]
+	expected := {
+		'lisp': ?WordLocation(none)
+	}
+	assert search(grid, words_to_search_for) == expected
+}
+
+fn test_should_not_wrap_around_vertically_to_find_a_word() {
+	grid := [
+		's',
+		'u',
+		'r',
+		'a',
+		'b',
+		'c',
+		't',
+	]
+	words_to_search_for := [
+		'rust',
+	]
+	expected := {
+		'rust': ?WordLocation(none)
+	}
+	assert search(grid, words_to_search_for) == expected
+}

--- a/exercises/practice/word-search/word-search.v
+++ b/exercises/practice/word-search/word-search.v
@@ -1,0 +1,15 @@
+module main
+
+// Grid rows and columns are 1-indexed.
+struct Pair {
+	column int
+	row    int
+}
+
+struct WordLocation {
+	start Pair
+	end   Pair
+}
+
+fn search(grid []string, words_to_search_for []string) map[string]?WordLocation {
+}


### PR DESCRIPTION
Function and argument names, and test cases, are taken from
https://github.com/exercism/problem-specifications/blob/main/exercises/word-search/canonical-data.json

_Option C_ from #124 comments is implemented: we return a map, with `none` used for words not present in the grid.
