### PR TITLE
Possible error in vlang test suite for clock exercise

### DIFF
--- a/exercises/practice/clock/run_test.v
+++ b/exercises/practice/clock/run_test.v
@@ -91,8 +91,8 @@ fn test_negative_60_minutes_previous_hour() {
 }
 
 fn test_negative_hour_and_minute_roll_over() {
-	c := new_clock(2, -60)
-	assert c.string() == '01:00'
+	c := new_clock(-25, -160)
+	assert c.string() == '20:20'
 }
 
 fn test_negative_hour_and_minute_roll_over_continuously() {


### PR DESCRIPTION
For the following test case:

```vlang
fn test_negative_hour_and_minute_roll_over() {
    c := new_clock(2, -60)
    assert c.string() == '01:00'
}
```

The description seems to imply that the hour should be negative, only the minute argument is. I suspect that this is a cut & paste error from the test case `test_negative_60_minutes_previous_hour` on lines 88-91

```vlang
fn test_negative_60_minutes_previous_hour() {
    c := new_clock(2, -60)
    assert c.string() == '01:00'
}
```