### PR TITLE
Adding Armstrong numbers to V practice questions

### DIFF
--- a/config.json
+++ b/config.json
@@ -362,6 +362,14 @@
         "difficulty": 4
       },
       {
+        "slug": "armstrong-numbers",
+        "name": "Armstrong Numbers",
+        "uuid": "3dd0d34b-1584-4960-bf82-beb2f4ca4e48",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
+      },
+      {
         "slug": "connect",
         "name": "Connect",
         "uuid": "3bbc3fc9-2bbe-4eec-ac5f-8736a0bf257d",

--- a/config.json
+++ b/config.json
@@ -367,7 +367,7 @@
         "uuid": "3dd0d34b-1584-4960-bf82-beb2f4ca4e48",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1
+        "difficulty": 3
       },
       {
         "slug": "connect",

--- a/exercises/practice/armstrong-numbers/.docs/instructions.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.md
@@ -1,0 +1,14 @@
+# Instructions
+
+An [Armstrong number][armstrong-number] is a number that is the sum of its own digits each raised to the power of the number of digits.
+
+For example:
+
+- 9 is an Armstrong number, because `9 = 9^1 = 9`
+- 10 is *not* an Armstrong number, because `10 != 1^2 + 0^2 = 1`
+- 153 is an Armstrong number, because: `153 = 1^3 + 5^3 + 3^3 = 1 + 125 + 27 = 153`
+- 154 is *not* an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
+
+Write some code to determine whether a number is an Armstrong number.
+
+[armstrong-number]: https://en.wikipedia.org/wiki/Narcissistic_number

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,0 +1,11 @@
+{
+  "authors": ["m-charlton"],
+  "files": {
+    "solution": ["armstrong-numbers.v"],
+    "test": ["run_test.v"],
+    "example": [".meta/example.v"]
+  },
+  "blurb": "Determine if a number is an Armstrong number.",
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"
+}

--- a/exercises/practice/armstrong-numbers/.meta/example.v
+++ b/exercises/practice/armstrong-numbers/.meta/example.v
@@ -1,10 +1,11 @@
 module main
 
-import math { log10, powi }
+import math { count_digits, powi }
 
 pub fn is_armstrong_number(number i64) bool {
-	num_of_digits := i64(log10(f64(number))) + 1
+	assert number >= 0, 'Armstrong numbers cannot be negative'
 
+	num_of_digits := count_digits(number)
 	mut sum := i64(0)
 
 	for div := number; div > 0; div /= 10 {

--- a/exercises/practice/armstrong-numbers/.meta/example.v
+++ b/exercises/practice/armstrong-numbers/.meta/example.v
@@ -1,0 +1,15 @@
+module main
+
+import math { log10, powi }
+
+pub fn is_armstrong_number(number i64) bool {
+	num_of_digits := i64(log10(f64(number))) + 1
+
+	mut sum := i64(0)
+
+	for div := number; div > 0; div /= 10 {
+		sum += powi(div % 10, num_of_digits)
+	}
+
+	return sum == number
+}

--- a/exercises/practice/armstrong-numbers/.meta/example.v
+++ b/exercises/practice/armstrong-numbers/.meta/example.v
@@ -2,15 +2,14 @@ module main
 
 import math { count_digits, powi }
 
-pub fn is_armstrong_number(number i64) bool {
-	assert number >= 0, 'Armstrong numbers cannot be negative'
-
-	num_of_digits := count_digits(number)
+pub fn is_armstrong_number(number u32) bool {
+	signed_num := i64(number)
+	num_of_digits := count_digits(signed_num)
 	mut sum := i64(0)
 
-	for div := number; div > 0; div /= 10 {
+	for div := signed_num; div > 0; div /= 10 {
 		sum += powi(div % 10, num_of_digits)
 	}
 
-	return sum == number
+	return sum == signed_num
 }

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c1ed103c-258d-45b2-be73-d8c6d9580c7b]
+description = "Zero is an Armstrong number"
+
+[579e8f03-9659-4b85-a1a2-d64350f6b17a]
+description = "Single-digit numbers are Armstrong numbers"
+
+[2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
+description = "There are no two-digit Armstrong numbers"
+
+[509c087f-e327-4113-a7d2-26a4e9d18283]
+description = "Three-digit number that is an Armstrong number"
+
+[7154547d-c2ce-468d-b214-4cb953b870cf]
+description = "Three-digit number that is not an Armstrong number"
+
+[6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
+description = "Four-digit number that is an Armstrong number"
+
+[eed4b331-af80-45b5-a80b-19c9ea444b2e]
+description = "Four-digit number that is not an Armstrong number"
+
+[f971ced7-8d68-4758-aea1-d4194900b864]
+description = "Seven-digit number that is an Armstrong number"
+
+[7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
+description = "Seven-digit number that is not an Armstrong number"
+
+[5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
+description = "Armstrong number containing seven zeroes"
+
+[12ffbf10-307a-434e-b4ad-c925680e1dd4]
+description = "The largest and last Armstrong number"

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.v
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.v
@@ -1,0 +1,4 @@
+module main
+
+pub fn is_armstrong_number(number i64) bool {
+}

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.v
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.v
@@ -1,4 +1,4 @@
 module main
 
-pub fn is_armstrong_number(number i64) bool {
+pub fn is_armstrong_number(number u32) bool {
 }

--- a/exercises/practice/armstrong-numbers/run_test.v
+++ b/exercises/practice/armstrong-numbers/run_test.v
@@ -1,0 +1,37 @@
+module main
+
+fn test_zero_is_an_armstrong_number() {
+	assert is_armstrong_number(0)
+}
+
+fn test_single_digit_numbers_are_armstrong_mumbers() {
+	assert is_armstrong_number(5)
+}
+
+fn test_there_are_no_2_digit_armstrong_numbers() {
+	assert !is_armstrong_number(10)
+}
+
+fn test_three_digit_number_that_is_an_armstrong_number() {
+	assert is_armstrong_number(153)
+}
+
+fn test_three_digit_number_that_is_not_an_armstrong_number() {
+	assert !is_armstrong_number(100)
+}
+
+fn test_four_digit_number_that_is_an_armstrong_number() {
+	assert is_armstrong_number(9474)
+}
+
+fn test_four_digit_number_that_is_not_an_armstrong_number() {
+	assert !is_armstrong_number(9475)
+}
+
+fn test_seven_digit_number_that_is_an_armstrong_number() {
+	assert is_armstrong_number(9926315)
+}
+
+fn test_seven_digit_number_that_is_not_an_armstrong_number() {
+	assert !is_armstrong_number(9926314)
+}


### PR DESCRIPTION
Two of the suggested tests; "Armstrong number containing seven zeroes" &
"The largest and last Armstrong number" not implemented as these tests are
involve numbers which require 128 bits, not yet supported by V.

### Query: negative Armstrong numbers 

According to [wikipedia](https://en.wikipedia.org/wiki/Narcissistic_number#Extension_to_negative_integers) narcissistic numbers can be negative.

$$
-8 = -8^1
$$

$$
-371 = -3^3 + -7^3 + -1^3
$$

$$
-9475 \neq -9^4 + -4^4 + -7^4 + -5^4
$$

$$
-9474 = -9^4 + -4^4 + -7^4 + -4^4
$$

If this is the case, do the test cases need updating?