### PR TITLE
feat(list-ops): add exercise list-ops to vlang track (resolves #144)

### DIFF
--- a/config.json
+++ b/config.json
@@ -114,6 +114,14 @@
         "difficulty": 3
       },
       {
+        "uuid": "c7b387ae-3ea2-40d2-9792-5f83d14f316e",
+        "slug": "list-ops",
+        "name": "List Ops",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
         "uuid": "e9a9d0d1-1756-4be5-8fc8-bd2d2d52611c",
         "slug": "grains",
         "name": "Grains",

--- a/config.json
+++ b/config.json
@@ -119,7 +119,7 @@
         "name": "List Ops",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 5
+        "difficulty": 6
       },
       {
         "uuid": "e9a9d0d1-1756-4be5-8fc8-bd2d2d52611c",

--- a/exercises/practice/list-ops/.docs/instructions.md
+++ b/exercises/practice/list-ops/.docs/instructions.md
@@ -1,0 +1,19 @@
+# Instructions
+
+Implement basic list operations.
+
+In functional languages list operations like `length`, `map`, and `reduce` are very common.
+Implement a series of basic list operations, without using existing functions.
+
+The precise number and names of the operations to be implemented will be track dependent to avoid conflicts with existing names, but the general operations you will implement include:
+
+- `append` (*given two lists, add all items in the second list to the end of the first list*);
+- `concatenate` (*given a series of lists, combine all items in all lists into one flattened list*);
+- `filter` (*given a predicate and a list, return the list of all items for which `predicate(item)` is True*);
+- `length` (*given a list, return the total number of items within it*);
+- `map` (*given a function and a list, return the list of the results of applying `function(item)` on all items*);
+- `foldl` (*given a function, a list, and initial accumulator, fold (reduce) each item into the accumulator from the left*);
+- `foldr` (*given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right*);
+- `reverse` (*given a list, return a list with all the original items, but in reversed order*).
+
+Note, the ordering in which arguments are passed to the fold functions (`foldl`, `foldr`) is significant.

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "authors": ["m-charlton"],
+  "files": {
+    "solution": ["list-ops.v"],
+    "test": ["run_test.v"],
+    "example": [".meta/example.v"]
+  },
+  "blurb": "Implement basic list operations."
+}

--- a/exercises/practice/list-ops/.meta/example.v
+++ b/exercises/practice/list-ops/.meta/example.v
@@ -1,0 +1,87 @@
+module main
+
+pub fn append[T](front []T, back []T) []T {
+	front_len := front.len
+
+	mut result := []T{len: front_len + back.len}
+
+	for i, element in front {
+		result[i] = element
+	}
+
+	for i, element in back {
+		result[front_len + i] = element
+	}
+
+	return result
+}
+
+pub fn concat[T](array [][]T) []T {
+	mut result_len := 0
+
+	for element in array {
+		result_len += element.len
+	}
+
+	mut result := []T{cap: result_len}
+
+	for element in array {
+		result = append(result, element)
+	}
+
+	return result
+}
+
+pub fn foldl[T, U](array []T, initial U, folder fn (acc U, e T) U) U {
+	mut result := initial
+
+	for element in array {
+		result = folder(result, element)
+	}
+
+	return result
+}
+
+pub fn foldr[T, U](array []T, initial U, folder fn (acc U, e T) U) U {
+	return foldl(reverse(array), initial, folder)
+}
+
+pub fn length[T](array []T) int {
+	return foldl[T, int](array, 0, fn [T](acc int, _ T) int {
+		return acc + 1
+	})
+}
+
+pub fn reverse[T](array []T) []T {
+	mut result := []T{cap: array.len}
+
+	for element in array {
+		result = append([element], result)
+	}
+
+	return result
+}
+
+pub fn filter[T](array []T, predicate fn (e T) bool) []T {
+	mut result := []T{cap: array.len}
+
+	for element in array {
+		if predicate(element) {
+			result = append(result, [element])
+		}
+	}
+
+	return result
+}
+
+// renamed 'map_of' as 'map' conflicts with V 'map' datatype
+
+pub fn map_of[T, U](array []T, mapper fn (e T) U) []U {
+	mut result := []U{cap: array.len}
+
+	for element in array {
+		result = append(result, [mapper(element)])
+	}
+
+	return result
+}

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -1,0 +1,106 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[485b9452-bf94-40f7-a3db-c3cf4850066a]
+description = "append entries to a list and return the new list -> empty lists"
+
+[2c894696-b609-4569-b149-8672134d340a]
+description = "append entries to a list and return the new list -> list to empty list"
+
+[e842efed-3bf6-4295-b371-4d67a4fdf19c]
+description = "append entries to a list and return the new list -> empty list to list"
+
+[71dcf5eb-73ae-4a0e-b744-a52ee387922f]
+description = "append entries to a list and return the new list -> non-empty lists"
+
+[28444355-201b-4af2-a2f6-5550227bde21]
+description = "concatenate a list of lists -> empty list"
+
+[331451c1-9573-42a1-9869-2d06e3b389a9]
+description = "concatenate a list of lists -> list of lists"
+
+[d6ecd72c-197f-40c3-89a4-aa1f45827e09]
+description = "concatenate a list of lists -> list of nested lists"
+
+[0524fba8-3e0f-4531-ad2b-f7a43da86a16]
+description = "filter list returning only values that satisfy the filter function -> empty list"
+
+[88494bd5-f520-4edb-8631-88e415b62d24]
+description = "filter list returning only values that satisfy the filter function -> non-empty list"
+
+[1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad]
+description = "returns the length of a list -> empty list"
+
+[d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e]
+description = "returns the length of a list -> non-empty list"
+
+[c0bc8962-30e2-4bec-9ae4-668b8ecd75aa]
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> empty list"
+
+[11e71a95-e78b-4909-b8e4-60cdcaec0e91]
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> non-empty list"
+
+[613b20b7-1873-4070-a3a6-70ae5f50d7cc]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+include = false
+
+[e56df3eb-9405-416a-b13a-aabb4c3b5194]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+include = false
+
+[d2cf5644-aee1-4dfc-9b88-06896676fe27]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+include = false
+
+[36549237-f765-4a4c-bfd9-5d3a8f7b07d2]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+reimplements = "613b20b7-1873-4070-a3a6-70ae5f50d7cc"
+
+[7a626a3c-03ec-42bc-9840-53f280e13067]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+reimplements = "e56df3eb-9405-416a-b13a-aabb4c3b5194"
+
+[d7fcad99-e88e-40e1-a539-4c519681f390]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+reimplements = "d2cf5644-aee1-4dfc-9b88-06896676fe27"
+
+[aeb576b9-118e-4a57-a451-db49fac20fdc]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+include = false
+
+[c4b64e58-313e-4c47-9c68-7764964efb8e]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+include = false
+
+[be396a53-c074-4db3-8dd6-f7ed003cce7c]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+include = false
+
+[17214edb-20ba-42fc-bda8-000a5ab525b0]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+reimplements = "aeb576b9-118e-4a57-a451-db49fac20fdc"
+
+[e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+reimplements = "c4b64e58-313e-4c47-9c68-7764964efb8e"
+
+[8066003b-f2ff-437e-9103-66e6df474844]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+reimplements = "be396a53-c074-4db3-8dd6-f7ed003cce7c"
+
+[94231515-050e-4841-943d-d4488ab4ee30]
+description = "reverse the elements of the list -> empty list"
+
+[fcc03d1e-42e0-4712-b689-d54ad761f360]
+description = "reverse the elements of the list -> non-empty list"
+
+[40872990-b5b8-4cb8-9085-d91fc0d05d26]
+description = "reverse the elements of the list -> list of lists is not flattened"

--- a/exercises/practice/list-ops/list-ops.v
+++ b/exercises/practice/list-ops/list-ops.v
@@ -10,7 +10,6 @@ pub fn foldl[T, U](array []T, initial U, folder fn (acc U, e T) U) U {
 }
 
 pub fn foldr[T, U](array []T, initial U, folder fn (acc U, e T) U) U {
-	return foldl(reverse(array), initial, folder)
 }
 
 pub fn length[T](array []T) int {

--- a/exercises/practice/list-ops/list-ops.v
+++ b/exercises/practice/list-ops/list-ops.v
@@ -1,0 +1,28 @@
+module main
+
+pub fn append[T](front []T, back []T) []T {
+}
+
+pub fn concat[T](array [][]T) []T {
+}
+
+pub fn foldl[T, U](array []T, initial U, folder fn (acc U, e T) U) U {
+}
+
+pub fn foldr[T, U](array []T, initial U, folder fn (acc U, e T) U) U {
+	return foldl(reverse(array), initial, folder)
+}
+
+pub fn length[T](array []T) int {
+}
+
+pub fn reverse[T](array []T) []T {
+}
+
+pub fn filter[T](array []T, predicate fn (e T) bool) []T {
+}
+
+// renamed 'map_of' as 'map' conflicts with V 'map' datatype
+
+pub fn map_of[T, U](array []T, mapper fn (e T) U) []U {
+}

--- a/exercises/practice/list-ops/run_test.v
+++ b/exercises/practice/list-ops/run_test.v
@@ -1,0 +1,170 @@
+module main
+
+const empty = []int{cap: 0}
+
+// append
+
+fn test_append_empty_lists() {
+	assert append[int](empty, empty) == empty
+}
+
+fn test_append_list_to_empty_list() {
+	assert append[int](empty, [1, 2, 3, 4]) == [1, 2, 3, 4]
+}
+
+fn test_append_empty_list_to_list() {
+	assert append[int]([1, 2, 3, 4], empty) == [1, 2, 3, 4]
+}
+
+fn test_append_non_empty_lists() {
+	assert append[int]([1, 2], [2, 3, 4, 5]) == [1, 2, 2, 3, 4, 5]
+}
+
+// concat
+
+fn test_concat_empty_list() {
+	assert concat[int]([empty]) == empty
+}
+
+fn test_concat_list_of_lists() {
+	assert concat[int]([[1, 2], [3], empty, [4, 5, 6]]) == [1, 2, 3, 4, 5, 6]
+}
+
+fn test_concat_list_of_nested_lists() {
+	assert concat[[]int]([[[1], [2]], [[3]], [[]], [[4, 5, 6]]]) == [
+		[1],
+		[2],
+		[3],
+		empty,
+		[4, 5, 6],
+	]
+}
+
+// filter
+
+fn test_filter_empty_list() {
+	assert filter[int](empty, fn (e int) bool {
+		return e % 2 == 1
+	}) == empty
+}
+
+fn test_filter_odd_numbers() {
+	assert filter[int]([1, 2, 3, 5], fn (e int) bool {
+		return e % 2 == 1
+	}) == [1, 3, 5]
+}
+
+// length
+
+fn test_length_of_empty_list() {
+	assert length[int](empty) == 0
+}
+
+fn test_length_of_non_empty_list() {
+	assert length[int]([1, 2, 3, 4]) == 4
+}
+
+// map_of
+
+fn test_map_of_empty_list() {
+	assert map_of[int, int](empty, fn (e int) int {
+		return e + 1
+	}) == empty
+}
+
+fn test_map_of_non_empty_list() {
+	assert map_of[int, int]([1, 3, 5, 7], fn (e int) int {
+		return e + 1
+	}) == [2, 4, 6, 8]
+}
+
+// foldl
+
+fn test_foldl_with_empty_list() {
+	assert foldl[int, int](empty, 2, fn (acc int, e int) int {
+		return acc * e
+	}) == 2
+}
+
+fn test_foldl_with_non_empty_list() {
+	assert foldl[int, int]([1, 2, 3, 4], 5, fn (acc int, e int) int {
+		return acc + e
+	}) == 15
+}
+
+fn test_foldl_with_non_empty_list_discard_fractional_division() {
+	assert foldl[int, int]([2, 5], 5, fn (acc int, e int) int {
+		return acc / e
+	}) == 0
+}
+
+fn test_foldl_with_empty_list_reversed_arguments() {
+	assert foldl[int, int](empty, 2, fn (acc int, e int) int {
+		return e * acc
+	}) == 2
+}
+
+fn test_foldl_with_non_empty_list_reversed_args() {
+	assert foldl[int, int]([1, 2, 3, 4], 5, fn (acc int, e int) int {
+		return e + acc
+	}) == 15
+}
+
+fn test_foldl_with_direction_dependent_function() {
+	assert foldl[int, int]([2, 5], 5, fn (acc int, e int) int {
+		return acc / e
+	}) == 0
+}
+
+// foldr
+
+fn test_foldr_with_empty_list() {
+	assert foldr[int, int](empty, 2, fn (acc int, e int) int {
+		return acc * e
+	}) == 2
+}
+
+fn test_foldr_with_non_empty_list() {
+	assert foldr[int, int]([1, 2, 3, 4], 5, fn (acc int, e int) int {
+		return acc + e
+	}) == 15
+}
+
+fn test_foldr_with_non_empty_list_directional_dependent_function() {
+	assert foldr[int, int]([2, 5], 5, fn (acc int, e int) int {
+		return acc / e
+	}) == 0
+}
+
+fn test_foldr_with_empty_list_reversed_args() {
+	assert foldr[int, int](empty, 2, fn (acc int, e int) int {
+		return e * acc
+	}) == 2
+}
+
+fn test_foldr_direction_independent_function_applied_to_non_empty_list() {
+	assert foldr[int, int]([1, 2, 3, 4], 5, fn (acc int, e int) int {
+		return e + acc
+	}) == 15
+}
+
+fn test_foldr_direction_dependent_function_applied_to_non_empty_list() {
+	assert foldr[int, int]([2, 5], 5, fn (acc int, e int) int {
+		return e / acc
+	}) == 2
+}
+
+// reverse
+
+fn test_reverse_empty_list() {
+	assert reverse[int](empty) == empty
+}
+
+fn test_reverse_non_empty_list() {
+	assert reverse[int]([1, 3, 5, 7]) == [7, 5, 3, 1]
+}
+
+fn test_reverse_list_of_lists_not_flattened() {
+	expected := [[4, 5, 6], empty, [3], [1, 2]]
+	assert reverse[[]int]([[1, 2], [3], empty, [4, 5, 6]]) == expected
+}


### PR DESCRIPTION
### General

Found this initially difficult. Though once I understood that an array could be a generic parameter, everything dropped into place. I've given this a difficulty rating of 5. What do you think?

This exercise requires an understanding of generics and touches on some aspects of functional programming techniques (mapping, filtering, folding, ..., etc). Do these topics need to be mentioned anywhere as a prerequisite in the `prerequisites` field of `list-ops/config.json`?

### Implementation (list-ops.v)

As per instructions the implementation uses no inbuilt functions/methods. I do call the `.len` property on an array though, but the `length` method could be used in its place.

All code has been tested with 2D arrays as input.

The `map` function has been changed to `map_of` to avoid a conflict with Vs built in map datatype.


### Tests (run_test.v)

All tests explicitly state the types of the generic parameters even if the compiler could infer them. The main reason for this is that the testcases will give the student a hint as to how to properly use generics to solve the
problem, especially when it comes to multi-dimensional (e.g. `[]int`)

`test_concat_empty_lists`(line 25). According to the [problem specification](https://github.com/exercism/problem-specifications/blob/main/exercises/list-ops/canonical-data.json) expects an input of `[]` & an output of `[]`. Because V is statically typed the input has been changed to `[[]]`.

`test_foldl_with_direction_dependent_function` (line 113) - uses the suggested test input from UUID `d2cf5664-...` due the integer division issue.

This is the test scenario I want you to examine `test_foldr_with_non_empty_list_directional_dependent_function` (line 133). From the problem specification:

```json
{
      "uuid": "be396a53-c074-4db3-8dd6-f7ed003cce7c",
      "description": "direction dependent function applied to non-empty list",
      "comments": [
        "Expects integer division (expects / to discard fractions).       "
      ],
      "property": "foldr",
      "input": {
        "list": [2, 5],
        "initial": 5,
        "function": "(x, y) -> x / y"
      },
      "expected": 2
}
```

I would expect 0 as the fractional part is discarded and I'm expecting 'x' to be the accumulator and 'y' the element. If the roles are transposed (i.e. x -> y, y -> x) then, we will get 2. There's a discussion [here](https://github.com/exercism/problem-specifications/pull/1746#discussion_r548303995).

I follow the V convention of specifying the accumulator as the first argument and the element as the second. See `arrays.reduce` & `arrays.fold`.

`test_foldr_direction_dependent_function_applied_to_non_empty_list` (line 151). Uses data from `be396a53-` due to discarding fractional part after division.