### PR TITLE
fix: the expect value to have 7 chunks a 8 chars, last two chunks 7 chars and trailing spaces

### DIFF
--- a/exercises/practice/crypto-square/run_test.v
+++ b/exercises/practice/crypto-square/run_test.v
@@ -44,6 +44,6 @@ fn test_8_character_plaintext_results_in_3_chunks_the_last_one_with_a_trailing_s
 
 fn test_54_character_plaintext_results_in_7_chunks_the_last_two_with_trailing_spaces() {
 	phrase := 'If man was meant to stay on the ground, god would have given us roots.'
-	expect := 'imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau '
+	expect := 'isotnugr fmshdlio metegdvo aaagohet nnyrdans wtoowvu atnuoes  '
 	assert ciphertext(phrase) == expect
 }


### PR DESCRIPTION
Seven chunks should be correct.
I am not sure about last two chunks, can the chunk before last one have 7 chars? If so, then this should fix it.

But it is not clear to me reading the instruction of the exercise.
