### PR TITLE
feat(test): port custom set exercise (resolves #148)

### DIFF
--- a/config.json
+++ b/config.json
@@ -130,6 +130,14 @@
         "difficulty": 3
       },
       {
+        "uuid": "7a75f29b-77a4-491f-84dd-bff01269a6b3",
+        "slug": "custom-set",
+        "name": "Custom Set",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
         "uuid": "e9a9d0d1-1756-4be5-8fc8-bd2d2d52611c",
         "slug": "grains",
         "name": "Grains",

--- a/exercises/practice/custom-set/.docs/instructions.md
+++ b/exercises/practice/custom-set/.docs/instructions.md
@@ -1,0 +1,7 @@
+# Instructions
+
+Create a custom set type.
+
+Sometimes it is necessary to define a custom data structure of some type, like a set.
+In this exercise you will define your own set.
+How it works internally doesn't matter, as long as it behaves like a set of unique elements.

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "authors": ["m-charlton"],
+  "files": {
+    "solution": ["custom-set.v"],
+    "test": ["run_test.v"],
+    "example": [".meta/example.v"]
+  },
+  "blurb": "Create a custom set type."
+}

--- a/exercises/practice/custom-set/.meta/example.v
+++ b/exercises/practice/custom-set/.meta/example.v
@@ -1,0 +1,77 @@
+module main
+
+import arrays { concat }
+import maps { from_array, invert, to_map }
+
+/*
+Why use a `map` and not an array?
+- no need to check when adding
+- membership tests faster (no need to check array):
+- an equality test would require both arrays to be in order
+  (i.e sorted)
+*/
+struct CustomSet[T] {
+mut:
+	items map[T]u8
+}
+
+[inline]
+fn (s CustomSet[T]) items() []T {
+	return s.items.keys()
+}
+
+/*
+This needs an explanation:
+
+	elements := ['a', 'b', 'c', 'b']
+	from_array(elements) => { 0: 'a', 1: 'b', 2: 'c', 3: 'b' }
+	invert({ 0: 'a', 1: 'b', 2: 'c', 3`: 'b'}) => { 'a': 0, 'c': 2, 'b': 3 }
+	to_map({ 'a': 0, 'c': 2, 'b': 3}) => { 'a': 1, 'c': 1, 'b': 1 }
+*/
+// build a new CustomSet
+pub fn CustomSet.new[T](elements []T) CustomSet[T] {
+	return CustomSet[T]{
+		items: to_map[T, int, T, int](invert[T, int](from_array[T](elements)), fn [T](key T, _ int) (T, u8) {
+			return key, 1
+		})
+	}
+}
+
+pub fn (mut s CustomSet[T]) add[T](element T) {
+	s.items[element] = 1
+}
+
+pub fn (s CustomSet[T]) contains[T](element T) bool {
+	return element in s.items
+}
+
+pub fn (s CustomSet[T]) equal[T](other CustomSet[T]) bool {
+	return s.items.len == other.items.len && s.items == other.items
+}
+
+pub fn (s CustomSet[T]) is_empty[T]() bool {
+	return s.items.len == 0
+}
+
+// @union to avoid conflict with reserved word 'union'
+pub fn (s CustomSet[T]) @union(other CustomSet[T]) CustomSet[T] {
+	return CustomSet.new(concat(s.items(), ...other.items()))
+}
+
+pub fn (s CustomSet[T]) intersection(other CustomSet[T]) CustomSet[T] {
+	return CustomSet.new[T](other.items().filter(s.contains(it)))
+}
+
+pub fn (s CustomSet[T]) difference[T](other CustomSet[T]) CustomSet[T] {
+	common := s.intersection(other)
+	return CustomSet.new[T](s.items().filter(!common.contains(it)))
+}
+
+pub fn (s CustomSet[T]) is_subset[T](other CustomSet[T]) bool {
+	return s.intersection(other).equal(s)
+}
+
+pub fn (s CustomSet[T]) is_disjoint[T](other CustomSet[T]) bool {
+	return s.intersection(other).is_empty()
+}
+

--- a/exercises/practice/custom-set/.meta/tests.toml
+++ b/exercises/practice/custom-set/.meta/tests.toml
@@ -1,0 +1,124 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[20c5f855-f83a-44a7-abdd-fe75c6cf022b]
+description = "Returns true if the set contains no elements -> sets with no elements are empty"
+
+[d506485d-5706-40db-b7d8-5ceb5acf88d2]
+description = "Returns true if the set contains no elements -> sets with elements are not empty"
+
+[759b9740-3417-44c3-8ca3-262b3c281043]
+description = "Sets can report if they contain an element -> nothing is contained in an empty set"
+
+[f83cd2d1-2a85-41bc-b6be-80adbff4be49]
+description = "Sets can report if they contain an element -> when the element is in the set"
+
+[93423fc0-44d0-4bc0-a2ac-376de8d7af34]
+description = "Sets can report if they contain an element -> when the element is not in the set"
+
+[c392923a-637b-4495-b28e-34742cd6157a]
+description = "A set is a subset if all of its elements are contained in the other set -> empty set is a subset of another empty set"
+
+[5635b113-be8c-4c6f-b9a9-23c485193917]
+description = "A set is a subset if all of its elements are contained in the other set -> empty set is a subset of non-empty set"
+
+[832eda58-6d6e-44e2-92c2-be8cf0173cee]
+description = "A set is a subset if all of its elements are contained in the other set -> non-empty set is not a subset of empty set"
+
+[c830c578-8f97-4036-b082-89feda876131]
+description = "A set is a subset if all of its elements are contained in the other set -> set is a subset of set with exact same elements"
+
+[476a4a1c-0fd1-430f-aa65-5b70cbc810c5]
+description = "A set is a subset if all of its elements are contained in the other set -> set is a subset of larger set with same elements"
+
+[d2498999-3e46-48e4-9660-1e20c3329d3d]
+description = "A set is a subset if all of its elements are contained in the other set -> set is not a subset of set that does not contain its elements"
+
+[7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc]
+description = "Sets are disjoint if they share no elements -> the empty set is disjoint with itself"
+
+[7a2b3938-64b6-4b32-901a-fe16891998a6]
+description = "Sets are disjoint if they share no elements -> empty set is disjoint with non-empty set"
+
+[589574a0-8b48-48ea-88b0-b652c5fe476f]
+description = "Sets are disjoint if they share no elements -> non-empty set is disjoint with empty set"
+
+[febeaf4f-f180-4499-91fa-59165955a523]
+description = "Sets are disjoint if they share no elements -> sets are not disjoint if they share an element"
+
+[0de20d2f-c952-468a-88c8-5e056740f020]
+description = "Sets are disjoint if they share no elements -> sets are disjoint if they share no elements"
+
+[4bd24adb-45da-4320-9ff6-38c044e9dff8]
+description = "Sets with the same elements are equal -> empty sets are equal"
+
+[f65c0a0e-6632-4b2d-b82c-b7c6da2ec224]
+description = "Sets with the same elements are equal -> empty set is not equal to non-empty set"
+
+[81e53307-7683-4b1e-a30c-7e49155fe3ca]
+description = "Sets with the same elements are equal -> non-empty set is not equal to empty set"
+
+[d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0]
+description = "Sets with the same elements are equal -> sets with the same elements are equal"
+
+[dd61bafc-6653-42cc-961a-ab071ee0ee85]
+description = "Sets with the same elements are equal -> sets with different elements are not equal"
+
+[06059caf-9bf4-425e-aaff-88966cb3ea14]
+description = "Sets with the same elements are equal -> set is not equal to larger set with same elements"
+
+[8a677c3c-a658-4d39-bb88-5b5b1a9659f4]
+description = "Unique elements can be added to a set -> add to empty set"
+
+[0903dd45-904d-4cf2-bddd-0905e1a8d125]
+description = "Unique elements can be added to a set -> add to non-empty set"
+
+[b0eb7bb7-5e5d-4733-b582-af771476cb99]
+description = "Unique elements can be added to a set -> adding an existing element does not change the set"
+
+[893d5333-33b8-4151-a3d4-8f273358208a]
+description = "Intersection returns a set of all shared elements -> intersection of two empty sets is an empty set"
+
+[d739940e-def2-41ab-a7bb-aaf60f7d782c]
+description = "Intersection returns a set of all shared elements -> intersection of an empty set and non-empty set is an empty set"
+
+[3607d9d8-c895-4d6f-ac16-a14956e0a4b7]
+description = "Intersection returns a set of all shared elements -> intersection of a non-empty set and an empty set is an empty set"
+
+[b5120abf-5b5e-41ab-aede-4de2ad85c34e]
+description = "Intersection returns a set of all shared elements -> intersection of two sets with no shared elements is an empty set"
+
+[af21ca1b-fac9-499c-81c0-92a591653d49]
+description = "Intersection returns a set of all shared elements -> intersection of two sets with shared elements is a set of the shared elements"
+
+[c5e6e2e4-50e9-4bc2-b89f-c518f015b57e]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of two empty sets is an empty set"
+
+[2024cc92-5c26-44ed-aafd-e6ca27d6fcd2]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of empty set and non-empty set is an empty set"
+
+[e79edee7-08aa-4c19-9382-f6820974b43e]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of a non-empty set and an empty set is the non-empty set"
+
+[c5ac673e-d707-4db5-8d69-7082c3a5437e]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of two non-empty sets is a set of elements that are only in the first set"
+
+[c45aed16-5494-455a-9033-5d4c93589dc6]
+description = "Union returns a set of all elements in either set -> union of empty sets is an empty set"
+
+[9d258545-33c2-4fcb-a340-9f8aa69e7a41]
+description = "Union returns a set of all elements in either set -> union of an empty set and non-empty set is the non-empty set"
+
+[3aade50c-80c7-4db8-853d-75bac5818b83]
+description = "Union returns a set of all elements in either set -> union of a non-empty set and empty set is the non-empty set"
+
+[a00bb91f-c4b4-4844-8f77-c73e2e9df77c]
+description = "Union returns a set of all elements in either set -> union of non-empty sets contains all unique elements"

--- a/exercises/practice/custom-set/custom-set.v
+++ b/exercises/practice/custom-set/custom-set.v
@@ -1,0 +1,36 @@
+module main
+
+struct CustomSet[T] {
+}
+
+// build a new CustomSet
+pub fn CustomSet.new[T](elements []T) CustomSet[T] {
+}
+
+pub fn (mut s CustomSet[T]) add[T](element T) {
+}
+
+pub fn (s CustomSet[T]) contains[T](element T) bool {
+}
+
+pub fn (s CustomSet[T]) equal[T](other CustomSet[T]) bool {
+}
+
+pub fn (s CustomSet[T]) is_empty[T]() bool {
+}
+
+// @union to avoid conflict with reserved word 'union'
+pub fn (s CustomSet[T]) @union(other CustomSet[T]) CustomSet[T] {
+}
+
+pub fn (s CustomSet[T]) intersection(other CustomSet[T]) CustomSet[T] {
+}
+
+pub fn (s CustomSet[T]) difference[T](other CustomSet[T]) CustomSet[T] {
+}
+
+pub fn (s CustomSet[T]) is_subset[T](other CustomSet[T]) bool {
+}
+
+pub fn (s CustomSet[T]) is_disjoint[T](other CustomSet[T]) bool {
+}

--- a/exercises/practice/custom-set/run_test.v
+++ b/exercises/practice/custom-set/run_test.v
@@ -1,0 +1,261 @@
+module main
+
+const (
+	empty         = CustomSet.new([]int{})
+	another_empty = CustomSet.new([]int{})
+	non_empty     = CustomSet.new([1])
+)
+
+// is_empty
+
+fn test_sets_with_no_elements_are_empty() {
+	assert empty.is_empty()
+}
+
+fn test_sets_with_elements_are_not_empty() {
+	assert !non_empty.is_empty()
+}
+
+// contains
+
+fn test_nothing_is_contained_in_an_empty_set() {
+	assert !empty.contains(1)
+}
+
+fn test_when_the_element_is_in_the_set() {
+	a_set := CustomSet.new([1, 2, 3])
+
+	assert a_set.contains(1)
+}
+
+fn test_when_the_element_is_not_in_the_set() {
+	a_set := CustomSet.new([1, 2, 3])
+
+	assert !a_set.contains(4)
+}
+
+// is_subset
+
+fn test_empty_set_is_a_subset_of_another_empty_set() {
+	assert empty.is_subset(another_empty)
+}
+
+fn test_empty_set_is_a_subset_of_non_empty_set() {
+	assert empty.is_subset(non_empty)
+}
+
+fn test_non_empty_set_is_not_a_subset_of_empty_set() {
+	assert !non_empty.is_subset(empty)
+}
+
+fn test_set_is_a_subset_of_set_with_exact_same_elements() {
+	a_set := CustomSet.new([1, 2, 3])
+	b_set := CustomSet.new([1, 2, 3])
+
+	assert a_set.is_subset(b_set)
+}
+
+fn test_set_is_a_subset_of_larger_set_with_same_elements() {
+	a_set := CustomSet.new([1, 2, 3])
+	b_set := CustomSet.new([1, 2, 3, 4])
+
+	assert a_set.is_subset(b_set)
+}
+
+fn test_set_is_not_a_subset_of_set_that_does_not_contain_its_elements() {
+	a_set := CustomSet.new([1, 2, 3])
+	b_set := CustomSet.new([4, 1, 3])
+
+	assert !a_set.is_subset(b_set)
+}
+
+// is_disjoint
+
+fn test_the_empty_set_is_disjoint_with_itself() {
+	assert empty.is_disjoint(another_empty)
+}
+
+fn test_empty_set_is_disjoint_with_non_empty_set() {
+	assert empty.is_disjoint(non_empty)
+}
+
+fn test_non_empty_set_is_disjoint_with_empty_set() {
+	assert non_empty.is_disjoint(empty)
+}
+
+fn test_sets_are_not_disjoint_if_they_share_an_element() {
+	a_set := CustomSet.new([1, 2])
+	b_set := CustomSet.new([2, 3])
+
+	assert !a_set.is_disjoint(b_set)
+}
+
+fn test_sets_are_disjoint_if_they_share_no_elements() {
+	a_set := CustomSet.new([1, 2])
+	b_set := CustomSet.new([3, 4])
+
+	assert a_set.is_disjoint(b_set)
+}
+
+// equal
+
+fn test_empty_sets_are_equal() {
+	assert empty.equal(another_empty)
+}
+
+fn test_empty_set_is_not_equal_to_non_empty_set() {
+	a_set := CustomSet.new([1, 2, 3])
+
+	assert !empty.equal(a_set)
+}
+
+fn test_non_empty_set_is_not_equal_to_empty_set() {
+	a_set := CustomSet.new([1, 2, 3])
+
+	assert !a_set.equal(empty)
+}
+
+fn test_sets_with_the_same_elements_are_equal() {
+	a_set := CustomSet.new([1, 2])
+	b_set := CustomSet.new([2, 1])
+
+	assert a_set.equal(b_set)
+}
+
+fn test_sets_with_different_elements_are_not_equal() {
+	a_set := CustomSet.new([1, 2, 3])
+	b_set := CustomSet.new([1, 2, 4])
+
+	assert !a_set.equal(b_set)
+}
+
+fn test_set_is_not_equal_to_larger_set_with_same_elements() {
+	a_set := CustomSet.new([1, 2, 3])
+	b_set := CustomSet.new([1, 2, 3, 4])
+
+	assert !a_set.equal(b_set)
+}
+
+// add
+
+fn test_add_to_empty_set() {
+	mut a_set := CustomSet.new([]int{})
+	expected := CustomSet.new([3])
+
+	a_set.add(3)
+
+	assert a_set.equal(expected)
+}
+
+fn test_add_to_non_empty_set() {
+	mut a_set := CustomSet.new([1, 2, 4])
+	expected := CustomSet.new([1, 2, 3, 4])
+
+	a_set.add(3)
+
+	assert a_set.equal(expected)
+}
+
+fn test_adding_an_existing_element_does_not_change_the_set() {
+	mut a_set := CustomSet.new([1, 2, 3])
+	expected := CustomSet.new([1, 2, 3])
+
+	a_set.add(3)
+
+	assert a_set.equal(expected)
+}
+
+// intersection
+
+fn test_intersection_of_two_empty_sets_is_an_empty_set() {
+	expected := CustomSet.new([]int{})
+
+	assert empty.intersection(another_empty).equal(expected)
+}
+
+fn test_intersection_of_an_empty_set_and_non_empty_set_is_an_empty_set() {
+	a_set := CustomSet.new([3, 2, 5])
+	expected := CustomSet.new([]int{})
+
+	assert empty.intersection(a_set).equal(expected)
+}
+
+fn test_intersection_of_a_non_empty_set_and_an_empty_set_is_an_empty_set() {
+	a_set := CustomSet.new([1, 2, 3, 4])
+
+	assert a_set.intersection(empty).equal(another_empty)
+}
+
+fn test_intersection_of_two_sets_with_no_shared_elements_is_an_empty_set() {
+	a_set := CustomSet.new([1, 2, 3])
+	b_set := CustomSet.new([4, 5, 6])
+
+	assert a_set.intersection(b_set).equal(empty)
+}
+
+fn test_intersection_of_two_sets_with_shared_elements_is_a_set_of_the_shared_elements() {
+	a_set := CustomSet.new([1, 2, 3, 4])
+	b_set := CustomSet.new([3, 2, 5])
+	expected := CustomSet.new([2, 3])
+
+	assert a_set.intersection(b_set).equal(expected)
+}
+
+// difference
+
+fn test_difference_of_two_empty_sets_is_an_empty_set() {
+	expected := CustomSet.new([]int{})
+
+	assert empty.difference(another_empty).equal(expected)
+}
+
+fn test_difference_of_empty_set_and_non_empty_set_is_an_empty_set() {
+	a_set := CustomSet.new([3, 2, 5])
+
+	assert empty.difference(a_set).equal(another_empty)
+}
+
+fn test_difference_of_a_non_empty_set_and_an_empty_set_is_the_non_empty_set() {
+	a_set := CustomSet.new([1, 2, 3, 4])
+	expected := CustomSet.new([1, 2, 3, 4])
+
+	assert a_set.difference(empty).equal(expected)
+}
+
+fn test_difference_of_two_non_empty_sets_is_a_set_of_elements_that_are_only_in_the_first_set() {
+	a_set := CustomSet.new([3, 2, 1])
+	b_set := CustomSet.new([2, 4])
+	expected := CustomSet.new([1, 3])
+
+	assert a_set.difference(b_set).equal(expected)
+}
+
+// @union
+
+fn test_union_of_empty_sets_is_an_empty_set() {
+	expected := CustomSet.new([]int{})
+
+	assert empty.@union(another_empty).equal(expected)
+}
+
+fn test_union_of_an_empty_set_and_non_empty_set_is_the_non_empty_set() {
+	a_set := CustomSet.new([2])
+	expected := CustomSet.new([2])
+
+	assert empty.@union(a_set).equal(expected)
+}
+
+fn test_union_of_a_non_empty_set_and_empty_set_is_the_non_empty_set() {
+	a_set := CustomSet.new([1, 3])
+	expected := CustomSet.new([1, 3])
+
+	assert a_set.@union(empty).equal(expected)
+}
+
+fn test_union_of_non_empty_sets_contains_all_unique_elements() {
+	a_set := CustomSet.new([1, 3])
+	b_set := CustomSet.new([2, 3])
+	expected := CustomSet.new([3, 2, 1])
+
+	assert a_set.@union(b_set).equal(expected)
+}


### PR DESCRIPTION
I'm using the preferred mechanism for building classes (`CustomSet.new()`). The union operation is changed to `@union` to avoid conflict with the `union` keyword.

Estimated this as a '5', difficulty wise.