### PR TITLE
feat(test): port rational numbers exercise (resolves #152)

### DIFF
--- a/config.json
+++ b/config.json
@@ -146,6 +146,14 @@
         "difficulty": 1
       },
       {
+        "uuid": "5cf96f11-1313-45e7-8f1b-2d9eaa6fa017",
+        "slug": "rational-numbers",
+        "name": "Rational Numbers",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4
+      },
+      {
         "uuid": "df360057-385e-4166-96e1-ed0629c02ca3",
         "slug": "two-fer",
         "name": "Two Fer",

--- a/exercises/practice/rational-numbers/.docs/instructions.md
+++ b/exercises/practice/rational-numbers/.docs/instructions.md
@@ -1,0 +1,42 @@
+# Instructions
+
+A rational number is defined as the quotient of two integers `a` and `b`, called the numerator and denominator, respectively, where `b != 0`.
+
+~~~~exercism/note
+Note that mathematically, the denominator can't be zero.
+However in many implementations of rational numbers, you will find that the denominator is allowed to be zero with behaviour similar to positive or negative infinity in floating point numbers.
+In those cases, the denominator and numerator generally still can't both be zero at once.
+~~~~
+
+The absolute value `|r|` of the rational number `r = a/b` is equal to `|a|/|b|`.
+
+The sum of two rational numbers `r₁ = a₁/b₁` and `r₂ = a₂/b₂` is `r₁ + r₂ = a₁/b₁ + a₂/b₂ = (a₁ * b₂ + a₂ * b₁) / (b₁ * b₂)`.
+
+The difference of two rational numbers `r₁ = a₁/b₁` and `r₂ = a₂/b₂` is `r₁ - r₂ = a₁/b₁ - a₂/b₂ = (a₁ * b₂ - a₂ * b₁) / (b₁ * b₂)`.
+
+The product (multiplication) of two rational numbers `r₁ = a₁/b₁` and `r₂ = a₂/b₂` is `r₁ * r₂ = (a₁ * a₂) / (b₁ * b₂)`.
+
+Dividing a rational number `r₁ = a₁/b₁` by another `r₂ = a₂/b₂` is `r₁ / r₂ = (a₁ * b₂) / (a₂ * b₁)` if `a₂` is not zero.
+
+Exponentiation of a rational number `r = a/b` to a non-negative integer power `n` is `r^n = (a^n)/(b^n)`.
+
+Exponentiation of a rational number `r = a/b` to a negative integer power `n` is `r^n = (b^m)/(a^m)`, where `m = |n|`.
+
+Exponentiation of a rational number `r = a/b` to a real (floating-point) number `x` is the quotient `(a^x)/(b^x)`, which is a real number.
+
+Exponentiation of a real number `x` to a rational number `r = a/b` is `x^(a/b) = root(x^a, b)`, where `root(p, q)` is the `q`th root of `p`.
+
+Implement the following operations:
+
+- addition, subtraction, multiplication and division of two rational numbers,
+- absolute value, exponentiation of a given rational number to an integer power, exponentiation of a given rational number to a real (floating-point) power, exponentiation of a real number to a rational number.
+
+Your implementation of rational numbers should always be reduced to lowest terms.
+For example, `4/4` should reduce to `1/1`, `30/60` should reduce to `1/2`, `12/8` should reduce to `3/2`, etc.
+To reduce a rational number `r = a/b`, divide `a` and `b` by the greatest common divisor (gcd) of `a` and `b`.
+So, for example, `gcd(12, 8) = 4`, so `r = 12/8` can be reduced to `(12/4)/(8/4) = 3/2`.
+The reduced form of a rational number should be in "standard form" (the denominator should always be a positive integer).
+If a denominator with a negative integer is present, multiply both numerator and denominator by `-1` to ensure standard form is reached.
+For example, `3/-4` should be reduced to `-3/4`
+
+Assume that the programming language you are using does not have an implementation of rational numbers.

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -1,0 +1,11 @@
+{
+  "authors": ["m-charlton"],
+  "files": {
+    "solution": ["rational-numbers.v"],
+    "test": ["run_test.v"],
+    "example": [".meta/example.v"]
+  },
+  "blurb": "Implement rational numbers.",
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Rational_number"
+}

--- a/exercises/practice/rational-numbers/.meta/example.v
+++ b/exercises/practice/rational-numbers/.meta/example.v
@@ -1,0 +1,77 @@
+module main
+
+import math { gcd, pow, powi, signi }
+
+struct Rational {
+	denominator i64
+	numerator   i64
+}
+
+// a/b -> b/a
+fn (r Rational) invert() Rational {
+	return Rational.new(r.numerator, r.denominator)
+}
+
+//  a/b -> -a/b
+// -a/b ->  a/b
+fn (r Rational) negate() Rational {
+	return Rational.new(-1 * r.denominator, r.numerator)
+}
+
+// build a new Rational number
+pub fn Rational.new(denominator i64, numerator i64) Rational {
+	assert numerator != 0
+
+	cmn_div := gcd(denominator, numerator)
+
+	sign := if signi(denominator) == -1 || signi(numerator) == -1 {
+		-1
+	} else {
+		1
+	}
+
+	return Rational{sign * math.abs(denominator) / cmn_div, math.abs(numerator) / cmn_div}
+}
+
+//  a/b -> a/b
+// -a/b -> a/b
+pub fn (r Rational) abs() Rational {
+	return Rational.new(math.abs(r.denominator), math.abs(r.numerator))
+}
+
+pub fn (r Rational) add(other Rational) Rational {
+	return Rational.new(r.denominator * other.numerator + other.denominator * r.numerator,
+		r.numerator * other.numerator)
+}
+
+pub fn (r Rational) div(other Rational) Rational {
+	return r.mul(other.invert())
+}
+
+// r^n
+pub fn (r Rational) exprational(n i64) Rational {
+	n_pos := math.abs(n)
+	result := Rational.new(powi(r.denominator, n_pos), powi(r.numerator, n_pos))
+
+	return match signi(n) {
+		1 { result }
+		else { result.invert() }
+	}
+}
+
+// n^r
+pub fn (r Rational) expreal(n i64) f64 {
+	return pow(n, f64(r.denominator) / f64(r.numerator))
+}
+
+pub fn (r Rational) mul(other Rational) Rational {
+	return Rational.new(r.denominator * other.denominator, r.numerator * other.numerator)
+}
+
+pub fn (r Rational) reduce() Rational {
+	return Rational.new(r.denominator, r.numerator)
+}
+
+pub fn (r Rational) sub(other Rational) Rational {
+	return r.add(other.negate())
+}

--- a/exercises/practice/rational-numbers/.meta/tests.toml
+++ b/exercises/practice/rational-numbers/.meta/tests.toml
@@ -1,0 +1,139 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[0ba4d988-044c-4ed5-9215-4d0bb8d0ae9f]
+description = "Arithmetic -> Addition -> Add two positive rational numbers"
+
+[88ebc342-a2ac-4812-a656-7b664f718b6a]
+description = "Arithmetic -> Addition -> Add a positive rational number and a negative rational number"
+
+[92ed09c2-991e-4082-a602-13557080205c]
+description = "Arithmetic -> Addition -> Add two negative rational numbers"
+
+[6e58999e-3350-45fb-a104-aac7f4a9dd11]
+description = "Arithmetic -> Addition -> Add a rational number to its additive inverse"
+
+[47bba350-9db1-4ab9-b412-4a7e1f72a66e]
+description = "Arithmetic -> Subtraction -> Subtract two positive rational numbers"
+
+[93926e2a-3e82-4aee-98a7-fc33fb328e87]
+description = "Arithmetic -> Subtraction -> Subtract a positive rational number and a negative rational number"
+
+[a965ba45-9b26-442b-bdc7-7728e4b8d4cc]
+description = "Arithmetic -> Subtraction -> Subtract two negative rational numbers"
+
+[0df0e003-f68e-4209-8c6e-6a4e76af5058]
+description = "Arithmetic -> Subtraction -> Subtract a rational number from itself"
+
+[34fde77a-75f4-4204-8050-8d3a937958d3]
+description = "Arithmetic -> Multiplication -> Multiply two positive rational numbers"
+
+[6d015cf0-0ea3-41f1-93de-0b8e38e88bae]
+description = "Arithmetic -> Multiplication -> Multiply a negative rational number by a positive rational number"
+
+[d1bf1b55-954e-41b1-8c92-9fc6beeb76fa]
+description = "Arithmetic -> Multiplication -> Multiply two negative rational numbers"
+
+[a9b8f529-9ec7-4c79-a517-19365d779040]
+description = "Arithmetic -> Multiplication -> Multiply a rational number by its reciprocal"
+
+[d89d6429-22fa-4368-ab04-9e01a44d3b48]
+description = "Arithmetic -> Multiplication -> Multiply a rational number by 1"
+
+[0d95c8b9-1482-4ed7-bac9-b8694fa90145]
+description = "Arithmetic -> Multiplication -> Multiply a rational number by 0"
+
+[1de088f4-64be-4e6e-93fd-5997ae7c9798]
+description = "Arithmetic -> Division -> Divide two positive rational numbers"
+
+[7d7983db-652a-4e66-981a-e921fb38d9a9]
+description = "Arithmetic -> Division -> Divide a positive rational number by a negative rational number"
+
+[1b434d1b-5b38-4cee-aaf5-b9495c399e34]
+description = "Arithmetic -> Division -> Divide two negative rational numbers"
+
+[d81c2ebf-3612-45a6-b4e0-f0d47812bd59]
+description = "Arithmetic -> Division -> Divide a rational number by 1"
+
+[5fee0d8e-5955-4324-acbe-54cdca94ddaa]
+description = "Absolute value -> Absolute value of a positive rational number"
+
+[3cb570b6-c36a-4963-a380-c0834321bcaa]
+description = "Absolute value -> Absolute value of a positive rational number with negative numerator and denominator"
+
+[6a05f9a0-1f6b-470b-8ff7-41af81773f25]
+description = "Absolute value -> Absolute value of a negative rational number"
+
+[5d0f2336-3694-464f-8df9-f5852fda99dd]
+description = "Absolute value -> Absolute value of a negative rational number with negative denominator"
+
+[f8e1ed4b-9dca-47fb-a01e-5311457b3118]
+description = "Absolute value -> Absolute value of zero"
+
+[4a8c939f-f958-473b-9f88-6ad0f83bb4c4]
+description = "Absolute value -> Absolute value of a rational number is reduced to lowest terms"
+
+[ea2ad2af-3dab-41e7-bb9f-bd6819668a84]
+description = "Exponentiation of a rational number -> Raise a positive rational number to a positive integer power"
+
+[8168edd2-0af3-45b1-b03f-72c01332e10a]
+description = "Exponentiation of a rational number -> Raise a negative rational number to a positive integer power"
+
+[c291cfae-cfd8-44f5-aa6c-b175c148a492]
+description = "Exponentiation of a rational number -> Raise a positive rational number to a negative integer power"
+
+[45cb3288-4ae4-4465-9ae5-c129de4fac8e]
+description = "Exponentiation of a rational number -> Raise a negative rational number to an even negative integer power"
+
+[2d47f945-ffe1-4916-a399-c2e8c27d7f72]
+description = "Exponentiation of a rational number -> Raise a negative rational number to an odd negative integer power"
+
+[e2f25b1d-e4de-4102-abc3-c2bb7c4591e4]
+description = "Exponentiation of a rational number -> Raise zero to an integer power"
+
+[431cac50-ab8b-4d58-8e73-319d5404b762]
+description = "Exponentiation of a rational number -> Raise one to an integer power"
+
+[7d164739-d68a-4a9c-b99f-dd77ce5d55e6]
+description = "Exponentiation of a rational number -> Raise a positive rational number to the power of zero"
+
+[eb6bd5f5-f880-4bcd-8103-e736cb6e41d1]
+description = "Exponentiation of a rational number -> Raise a negative rational number to the power of zero"
+
+[30b467dd-c158-46f5-9ffb-c106de2fd6fa]
+description = "Exponentiation of a real number to a rational number -> Raise a real number to a positive rational number"
+
+[6e026bcc-be40-4b7b-ae22-eeaafc5a1789]
+description = "Exponentiation of a real number to a rational number -> Raise a real number to a negative rational number"
+
+[9f866da7-e893-407f-8cd2-ee85d496eec5]
+description = "Exponentiation of a real number to a rational number -> Raise a real number to a zero rational number"
+
+[0a63fbde-b59c-4c26-8237-1e0c73354d0a]
+description = "Reduction to lowest terms -> Reduce a positive rational number to lowest terms"
+
+[5ed6f248-ad8d-4d4e-a545-9146c6727f33]
+description = "Reduction to lowest terms -> Reduce places the minus sign on the numerator"
+
+[f87c2a4e-d29c-496e-a193-318c503e4402]
+description = "Reduction to lowest terms -> Reduce a negative rational number to lowest terms"
+
+[3b92ffc0-5b70-4a43-8885-8acee79cdaaf]
+description = "Reduction to lowest terms -> Reduce a rational number with a negative denominator to lowest terms"
+
+[c9dbd2e6-5ac0-4a41-84c1-48b645b4f663]
+description = "Reduction to lowest terms -> Reduce zero to lowest terms"
+
+[297b45ad-2054-4874-84d4-0358dc1b8887]
+description = "Reduction to lowest terms -> Reduce an integer to lowest terms"
+
+[a73a17fe-fe8c-4a1c-a63b-e7579e333d9e]
+description = "Reduction to lowest terms -> Reduce one to lowest terms"

--- a/exercises/practice/rational-numbers/rational-numbers.v
+++ b/exercises/practice/rational-numbers/rational-numbers.v
@@ -1,0 +1,32 @@
+module main
+
+struct Rational {
+}
+
+// build a new Rational number
+pub fn Rational.new(denominator i64, numerator i64) Rational {
+}
+
+pub fn (r Rational) abs() Rational {
+}
+
+pub fn (r Rational) add(other Rational) Rational {
+}
+
+pub fn (r Rational) div(other Rational) Rational {
+}
+
+pub fn (r Rational) exprational(n i64) Rational {
+}
+
+pub fn (r Rational) expreal(n i64) f64 {
+}
+
+pub fn (r Rational) mul(other Rational) Rational {
+}
+
+pub fn (r Rational) reduce() Rational {
+}
+
+pub fn (r Rational) sub(other Rational) Rational {
+}

--- a/exercises/practice/rational-numbers/run_test.v
+++ b/exercises/practice/rational-numbers/run_test.v
@@ -1,0 +1,301 @@
+module main
+
+import math
+
+// assert if 'actual' and 'expected' are _not_ within 1e-14 of each other
+fn assert_close_enough(actual f64, expected f64) {
+	assert math.close(actual, expected), 'actual = ${actual}, expected = ${expected}'
+}
+
+// tests
+
+// add
+
+fn test_add_two_positive_rational_numbers() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(2, 3)
+
+	assert r1.add(r2) == Rational.new(7, 6)
+}
+
+fn test_add_a_positive_rational_number_and_a_negative_rational_number() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(-2, 3)
+
+	assert r1.add(r2) == Rational.new(-1, 6)
+}
+
+fn test_add_two_negative_rational_numbers() {
+	r1 := Rational.new(-1, 2)
+	r2 := Rational.new(-2, 3)
+
+	assert r1.add(r2) == Rational.new(-7, 6)
+}
+
+fn test_add_a_rational_number_to_its_additive_inverse() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(-1, 2)
+
+	assert r1.add(r2) == Rational.new(0, 1)
+}
+
+// subtract (sub)
+
+fn test_subtract_two_positive_rational_numbers() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(2, 3)
+
+	assert r1.sub(r2) == Rational.new(-1, 6)
+}
+
+fn test_subtract_a_positive_rational_number_and_a_negative_rational_number() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(-2, 3)
+
+	assert r1.sub(r2) == Rational.new(7, 6)
+}
+
+fn test_subtract_two_negative_rational_numbers() {
+	r1 := Rational.new(-1, 2)
+	r2 := Rational.new(-2, 3)
+
+	assert r1.sub(r2) == Rational.new(1, 6)
+}
+
+fn test_subtract_a_rational_number_from_itself() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(1, 2)
+
+	assert r1.sub(r2) == Rational.new(0, 1)
+}
+
+// multiply (mul)
+
+fn test_multiply_two_positive_rational_numbers() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(2, 3)
+
+	assert r1.mul(r2) == Rational.new(1, 3)
+}
+
+fn test_multiply_a_negative_rational_number_by_a_positive_rational_number() {
+	r1 := Rational.new(-1, 2)
+	r2 := Rational.new(2, 3)
+
+	assert r1.mul(r2) == Rational.new(-1, 3)
+}
+
+fn test_multiply_two_negative_rational_numbers() {
+	r1 := Rational.new(-1, 2)
+	r2 := Rational.new(-2, 3)
+
+	assert r1.mul(r2) == Rational.new(1, 3)
+}
+
+fn test_multiply_a_rational_number_by_its_reciprocal() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(2, 1)
+
+	assert r1.mul(r2) == Rational.new(1, 1)
+}
+
+fn test_multiply_a_rational_number_by_1() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(1, 1)
+
+	assert r1.mul(r2) == Rational.new(1, 2)
+}
+
+fn test_multiply_a_rational_number_by_0() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(0, 1)
+
+	assert r1.mul(r2) == Rational.new(0, 1)
+}
+
+// divide (div)
+
+fn test_divide_two_positive_rational_numbers() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(2, 3)
+
+	assert r1.div(r2) == Rational.new(3, 4)
+}
+
+fn test_divide_a_positive_rational_number_by_a_negative_rational_number() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(-2, 3)
+
+	assert r1.div(r2) == Rational.new(-3, 4)
+}
+
+fn test_divide_two_negative_rational_numbers() {
+	r1 := Rational.new(-1, 2)
+	r2 := Rational.new(-2, 3)
+
+	assert r1.div(r2) == Rational.new(3, 4)
+}
+
+fn test_divide_a_rational_number_by_1() {
+	r1 := Rational.new(1, 2)
+	r2 := Rational.new(1, 1)
+
+	assert r1.div(r2) == Rational.new(1, 2)
+}
+
+// absolute value (abs)
+
+fn test_absolute_value_of_a_positive_rational_number() {
+	r := Rational.new(1, 2)
+
+	assert r.abs() == Rational.new(1, 2)
+}
+
+fn test_absolute_value_of_a_positive_rational_number_with_negative_numerator_and_denominator() {
+	r := Rational.new(-1, -2)
+
+	assert r.abs() == Rational.new(1, 2)
+}
+
+fn test_absolute_value_of_a_negative_rational_number() {
+	r := Rational.new(-1, 2)
+
+	assert r.abs() == Rational.new(1, 2)
+}
+
+fn test_absolute_value_of_a_negative_rational_number_with_negative_denominator() {
+	r := Rational.new(1, -2)
+
+	assert r.abs() == Rational.new(1, 2)
+}
+
+fn test_absolute_value_of_zero() {
+	r := Rational.new(0, 1)
+
+	assert r.abs() == Rational.new(0, 1)
+}
+
+fn test_absolute_value_of_a_rational_number_is_reduced_to_lowest_terms() {
+	r := Rational.new(2, 4)
+
+	assert r.abs() == Rational.new(1, 2)
+}
+
+// exprational (r^n)
+
+fn test_raise_a_positive_rational_number_to_a_positive_integer_power() {
+	r := Rational.new(1, 2)
+
+	assert r.exprational(3) == Rational.new(1, 8)
+}
+
+fn test_raise_a_negative_rational_number_to_a_positive_integer_power() {
+	r := Rational.new(-1, 2)
+
+	assert r.exprational(3) == Rational.new(-1, 8)
+}
+
+fn test_raise_a_positive_rational_number_to_a_negative_integer_power() {
+	r := Rational.new(3, 5)
+
+	assert r.exprational(-2) == Rational.new(25, 9)
+}
+
+fn test_raise_a_negative_rational_number_to_an_even_negative_integer_power() {
+	r := Rational.new(-3, 5)
+
+	assert r.exprational(-2) == Rational.new(25, 9)
+}
+
+fn test_raise_a_negative_rational_number_to_an_odd_negative_integer_power() {
+	r := Rational.new(-3, 5)
+
+	assert r.exprational(-3) == Rational.new(-125, 27)
+}
+
+fn test_raise_zero_to_an_integer_power() {
+	r := Rational.new(0, 1)
+
+	assert r.exprational(5) == Rational.new(0, 1)
+}
+
+fn test_raise_one_to_an_integer_power() {
+	r := Rational.new(1, 1)
+
+	assert r.exprational(4) == Rational.new(1, 1)
+}
+
+fn test_raise_a_positive_rational_number_to_the_power_of_zero() {
+	r := Rational.new(1, 2)
+
+	assert r.exprational(0) == Rational.new(1, 1)
+}
+
+fn test_raise_a_negative_rational_number_to_the_power_of_zero() {
+	r := Rational.new(-1, 2)
+
+	assert r.exprational(0) == Rational.new(1, 1)
+}
+
+// expreal (n^r)
+fn test_raise_a_real_number_to_a_positive_rational_number() {
+	r := Rational.new(4, 3)
+
+	assert_close_enough(r.expreal(8), 16.0)
+}
+
+fn test_raise_a_real_number_to_a_negative_rational_number() {
+	r := Rational.new(-1, 2)
+
+	assert_close_enough(r.expreal(9), 0.33333333333333333)
+}
+
+fn test_raise_a_real_number_to_a_zero_rational_number() {
+	r := Rational.new(0, 1)
+
+	assert_close_enough(r.expreal(2), 1.0)
+}
+
+// reduce
+
+fn test_reduce_a_positive_rational_number_to_lowest_terms() {
+	r := Rational.new(2, 4)
+
+	assert r.reduce() == Rational.new(1, 2)
+}
+
+fn test_reduce_places_the_minus_sign_on_the_numerator() {
+	r := Rational.new(3, -4)
+
+	assert r.reduce() == Rational.new(-3, 4)
+}
+
+fn test_reduce_a_negative_rational_number_to_lowest_terms() {
+	r := Rational.new(-4, 6)
+
+	assert r.reduce() == Rational.new(-2, 3)
+}
+
+fn test_reduce_a_rational_number_with_a_negative_denominator_to_lowest_terms() {
+	r := Rational.new(3, -9)
+
+	assert r.reduce() == Rational.new(-1, 3)
+}
+
+fn test_reduce_zero_to_lowest_terms() {
+	r := Rational.new(0, 6)
+
+	assert r.reduce() == Rational.new(0, 1)
+}
+
+fn test_reduce_an_integer_to_lowest_terms() {
+	r := Rational.new(-14, 7)
+
+	assert r.reduce() == Rational.new(-2, 1)
+}
+
+fn test_reduce_one_to_lowest_terms() {
+	r := Rational.new(13, 13)
+
+	assert r.reduce() == Rational.new(1, 1)
+}


### PR DESCRIPTION
Added the `Rational.new(...)` function as the preferred mechanism for creating `Rational` objects. The test suite has an `assert_close_enough(...)` function which will only fail if the difference between expected and actual exceeds `1e-14`. If this error margin needs to be configurable then the [`math.tolerance(...)`](https://modules.vlang.io/math.html#tolerance) function could be used instead of [`math.close(...)`](https://modules.vlang.io/math.html#close). There's also a [`math.veryclose(...)`](https://modules.vlang.io/math.html#veryclose) function with a tolerance of `4e-16`.

I've assigned a difficulty level of '4', it was a coin-flip between '4' or '5'.