### PR TITLE
feat: add high-scores exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -394,6 +394,14 @@
         "difficulty": 4
       },
       {
+        "slug": "high-scores",
+        "name": "High Scores",
+        "uuid": "694ade58-8851-4050-afa0-81fad339e21f",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "slug": "resistor-color-duo",
         "name": "Resistor Color Duo",
         "uuid": "6f955919-1478-4296-ae5c-8c3caf06d614",

--- a/exercises/practice/high-scores/.docs/instructions.md
+++ b/exercises/practice/high-scores/.docs/instructions.md
@@ -1,0 +1,6 @@
+# Instructions
+
+Manage a game player's High Score list.
+
+Your task is to build a high-score component of the classic Frogger game, one of the highest selling and most addictive games of all time, and a classic of the arcade era.
+Your task is to write methods that return the highest score from the list, the last added score and the three highest scores.

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,0 +1,18 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "high-scores.v"
+    ],
+    "test": [
+      "run_test.v"
+    ],
+    "example": [
+      ".meta/example.v"
+    ]
+  },
+  "blurb": "Manage a player's High Score list.",
+  "source": "Tribute to the eighties' arcade game Frogger"
+}

--- a/exercises/practice/high-scores/.meta/example.v
+++ b/exercises/practice/high-scores/.meta/example.v
@@ -1,0 +1,35 @@
+module main
+
+struct HighScores {
+	scores []int
+}
+
+// build a new HighScores
+pub fn HighScores.new(scores []int) HighScores {
+	return HighScores{
+		scores: scores
+	}
+}
+
+pub fn (mut high_scores HighScores) scores() []int {
+	return high_scores.scores
+}
+
+pub fn (mut high_scores HighScores) latest() int {
+	return high_scores.scores.last()
+}
+
+pub fn (mut high_scores HighScores) personal_best() int {
+	mut sorted := high_scores.scores.clone()
+	sorted.sort()
+	return sorted.last()
+}
+
+pub fn (mut high_scores HighScores) personal_top_three() []int {
+	mut sorted := high_scores.scores.clone()
+	sorted.sort()
+	if sorted.len > 3 {
+		sorted.drop(sorted.len - 3)
+	}
+	return sorted.reverse()
+}

--- a/exercises/practice/high-scores/.meta/tests.toml
+++ b/exercises/practice/high-scores/.meta/tests.toml
@@ -1,0 +1,39 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[1035eb93-2208-4c22-bab8-fef06769a73c]
+description = "List of scores"
+
+[6aa5dbf5-78fa-4375-b22c-ffaa989732d2]
+description = "Latest score"
+
+[b661a2e1-aebf-4f50-9139-0fb817dd12c6]
+description = "Personal best"
+
+[3d996a97-c81c-4642-9afc-80b80dc14015]
+description = "Top 3 scores -> Personal top three from a list of scores"
+
+[1084ecb5-3eb4-46fe-a816-e40331a4e83a]
+description = "Top 3 scores -> Personal top highest to lowest"
+
+[e6465b6b-5a11-4936-bfe3-35241c4f4f16]
+description = "Top 3 scores -> Personal top when there is a tie"
+
+[f73b02af-c8fd-41c9-91b9-c86eaa86bce2]
+description = "Top 3 scores -> Personal top when there are less than 3"
+
+[16608eae-f60f-4a88-800e-aabce5df2865]
+description = "Top 3 scores -> Personal top when there is only one"
+
+[2df075f9-fec9-4756-8f40-98c52a11504f]
+description = "Top 3 scores -> Latest score after personal top scores"
+
+[809c4058-7eb1-4206-b01e-79238b9b71bc]
+description = "Top 3 scores -> Scores after personal top scores"
+
+[ddb0efc0-9a86-4f82-bc30-21ae0bdc6418]
+description = "Top 3 scores -> Latest score after personal best"
+
+[6a0fd2d1-4cc4-46b9-a5bb-2fb667ca2364]
+description = "Top 3 scores -> Scores after personal best"

--- a/exercises/practice/high-scores/high-scores.v
+++ b/exercises/practice/high-scores/high-scores.v
@@ -1,0 +1,20 @@
+module main
+
+struct HighScores {
+}
+
+// build a new HighScores
+pub fn HighScores.new(scores []int) HighScores {
+}
+
+pub fn (mut high_scores HighScores) scores() []int {
+}
+
+pub fn (mut high_scores HighScores) latest() int {
+}
+
+pub fn (mut high_scores HighScores) personal_best() int {
+}
+
+pub fn (mut high_scores HighScores) personal_top_three() []int {
+}

--- a/exercises/practice/high-scores/run_test.v
+++ b/exercises/practice/high-scores/run_test.v
@@ -1,0 +1,73 @@
+module main
+
+fn test_list_of_scores() {
+	mut high_scores := HighScores.new([30, 50, 20, 70])
+	expect := [30, 50, 20, 70]
+	assert high_scores.scores() == expect
+}
+
+fn test_latest_score() {
+	mut high_scores := HighScores.new([100, 0, 90, 30])
+	assert high_scores.latest() == 30
+}
+
+fn test_personal_best() {
+	mut high_scores := HighScores.new([40, 100, 70])
+	assert high_scores.personal_best() == 100
+}
+
+fn test_top_3_scores__personal_top_three_from_a_list_of_scores() {
+	mut high_scores := HighScores.new([10, 30, 90, 30, 100, 20, 10, 0, 30, 40, 40, 70, 70])
+	expect := [100, 90, 70]
+	assert high_scores.personal_top_three() == expect
+}
+
+fn test_top_3_scores__personal_top_highest_to_lowest() {
+	mut high_scores := HighScores.new([20, 10, 30])
+	expect := [30, 20, 10]
+	assert high_scores.personal_top_three() == expect
+}
+
+fn test_top_3_scores__personal_top_when_there_is_a_tie() {
+	mut high_scores := HighScores.new([40, 20, 40, 30])
+	expect := [40, 40, 30]
+	assert high_scores.personal_top_three() == expect
+}
+
+fn test_top_3_scores__personal_top_when_there_are_less_than_3() {
+	mut high_scores := HighScores.new([30, 70])
+	expect := [70, 30]
+	assert high_scores.personal_top_three() == expect
+}
+
+fn test_top_3_scores__personal_top_when_there_is_only_one() {
+	mut high_scores := HighScores.new([40])
+	expect := [40]
+	assert high_scores.personal_top_three() == expect
+}
+
+fn test_top_3_scores__latest_score_after_personal_top_scores() {
+	mut high_scores := HighScores.new([70, 50, 20, 30])
+	high_scores.personal_top_three()
+	assert high_scores.latest() == 30
+}
+
+fn test_top_3_scores__scores_after_personal_top_scores() {
+	mut high_scores := HighScores.new([30, 50, 20, 70])
+	high_scores.personal_top_three()
+	expect := [30, 50, 20, 70]
+	assert high_scores.scores() == expect
+}
+
+fn test_top_3_scores__latest_score_after_personal_best() {
+	mut high_scores := HighScores.new([20, 70, 15, 25, 30])
+	high_scores.personal_best()
+	assert high_scores.latest() == 30
+}
+
+fn test_top_3_scores__scores_after_personal_best() {
+	mut high_scores := HighScores.new([20, 70, 15, 25, 30])
+	high_scores.personal_best()
+	expect := [20, 70, 15, 25, 30]
+	assert high_scores.scores() == expect
+}


### PR DESCRIPTION
The last four canonical test cases for this exercise check that calling one method doesn't stop another method from returning the correct result.

These test cases are the reason I used `(mut high_scores HighScores)` - without the `mut`, those test cases would be largely redundant.
