### PR TITLE
Fix time parsing in gigasecond tests

### DIFF
--- a/exercises/practice/gigasecond/run_test.v
+++ b/exercises/practice/gigasecond/run_test.v
@@ -3,27 +3,27 @@ module main
 import time
 
 fn test_date_specified_of_time() {
-	assert add_gigasecond(time.parse_rfc3339('2011-04-25')!) == time.parse_rfc3339('2043-01-01T01:46:40')!
+	assert add_gigasecond(time.parse_iso8601('2011-04-25')!) == time.parse_iso8601('2043-01-01T01:46:40')!
 }
 
 fn test_second_date_specified_of_time() {
-	assert add_gigasecond(time.parse_rfc3339('1977-06-13')!) == time.parse_rfc3339('2009-02-19T01:46:40')!
+	assert add_gigasecond(time.parse_iso8601('1977-06-13')!) == time.parse_iso8601('2009-02-19T01:46:40')!
 }
 
 fn test_third_date_specified_of_time() {
-	assert add_gigasecond(time.parse_rfc3339('1959-07-19')!) == time.parse_rfc3339('1991-03-27T01:46:40')!
+	assert add_gigasecond(time.parse_iso8601('1959-07-19')!) == time.parse_iso8601('1991-03-27T01:46:40')!
 }
 
 fn test_full_time_specified() {
-	assert add_gigasecond(time.parse_rfc3339('2015-01-24T22:00:00')!) == time.parse_rfc3339('2046-10-02T23:46:40')!
+	assert add_gigasecond(time.parse_iso8601('2015-01-24T22:00:00')!) == time.parse_iso8601('2046-10-02T23:46:40')!
 }
 
 fn test_full_time_with_day_roll_over() {
-	assert add_gigasecond(time.parse_rfc3339('2015-01-24T23:59:59')!) == time.parse_rfc3339('2046-10-03T01:46:39')!
+	assert add_gigasecond(time.parse_iso8601('2015-01-24T23:59:59')!) == time.parse_iso8601('2046-10-03T01:46:39')!
 }
 
 fn test_immutable() {
-	moment := time.parse_rfc3339('2015-01-24T23:59:59')!
+	moment := time.parse_iso8601('2015-01-24T23:59:59')!
 	res := add_gigasecond(moment)
-	assert moment == time.parse_rfc3339('2015-01-24T23:59:59')!
+	assert moment == time.parse_iso8601('2015-01-24T23:59:59')!
 }


### PR DESCRIPTION
As mentioned in #232, this is to fix the Gigasecond tests (failed in test run https://github.com/exercism/vlang/actions/runs/11506925109).

This fixes the parsing of the date strings in the tests. According to the docs the, a couple of the dates are in ISO 8601 format rather than RFC 3339. RFC 3339 requires the time zone to be specified when the String contains a time. ISO 8601 doesn't have this requirment.

See:
- https://modules.vlang.io/time.html#parse_rfc3339
- https://ijmacd.github.io/rfc3339-iso8601/

When merging, I think it should be marked `[no important files changed]` as this commit shouldn't change any past test results.