### PR TITLE
Update to work with Vlang 0.4.9

### DIFF
--- a/exercises/practice/list-ops/run_test.v
+++ b/exercises/practice/list-ops/run_test.v
@@ -31,7 +31,7 @@ fn test_concat_list_of_lists() {
 }
 
 fn test_concat_list_of_nested_lists() {
-	assert concat[[]int]([[[1], [2]], [[3]], [[]], [[4, 5, 6]]]) == [
+	assert concat[[]int]([[[1], [2]], [[3]], [[]int{}], [[4, 5, 6]]]) == [
 		[1],
 		[2],
 		[3],

--- a/exercises/practice/parallel-letter-frequency/.meta/example.v
+++ b/exercises/practice/parallel-letter-frequency/.meta/example.v
@@ -6,7 +6,7 @@ fn count_letters(word string) map[rune]int {
 	mut result := map[rune]int{}
 	lower := utf8.to_lower(word)
 	for r in 0 .. utf8.len(lower) {
-		c := utf8.get_uchar(lower, r)
+		c := utf8.get_rune(lower, r)
 		if utf8.is_letter(rune(c)) {
 			result[c]++
 		}


### PR DESCRIPTION
The commits in this PR fixes a build failure and a warning in the CI https://github.com/exercism/vlang/actions/runs/12798355176/job/35682210581?pr=236.

More specifically, the error is:
```
 ---- Testing... ----------------------------------------------------------------
Error: temp/run_test.v:34:44: error: array_init: no type specified (maybe: `[]Type{}` instead of `[]`)
   32 | 
   33 | fn test_concat_list_of_nested_lists() {
   34 |     assert concat[[]int]([[[1], [2]], [[3]], [[]], [[4, 5, 6]]]) == [
      |                                               ~~~
   35 |         [1],
   36 |         [2],
Error: temp/run_test.v:34:44: error: invalid void array element type
   32 | 
   33 | fn test_concat_list_of_nested_lists() {
   34 |     assert concat[[]int]([[[1], [2]], [[3]], [[]], [[4, 5, 6]]]) == [
      |                                               ~~~
   35 |         [1],
   36 |         [2],
Error: temp/run_test.v:34:43: error: invalid array element: expected `[][]int`, not `[]void`
   32 | 
   33 | fn test_concat_list_of_nested_lists() {
   34 |     assert concat[[]int]([[[1], [2]], [[3]], [[]], [[4, 5, 6]]]) == [
      |                                              ~~~~
   35 |         [1],
   36 |         [2],
checker summary: 3 V errors, 0 V warnings, 0 V notices
```

and the warning is:
```
Warning: temp/parallel_letter_frequency.v:9:13: warning: function `encoding.utf8.get_uchar` has been deprecated since 2024-11-17, it will be an error after 2025-05-16; use `.get_rune(s string, index int)` instead
--------------------------------------------------------------------------------
    7 |     lower := utf8.to_lower(word)
    8 |     for r in 0 .. utf8.len(lower) {
    9 |         c := utf8.get_uchar(lower, r)
      |                   ~~~~~~~~~~~~~~~~~~~
   10 |         if utf8.is_letter(rune(c)) {
   11 |             result[c]++
```