### PR TITLE
Replace map with array in custom-set example

### DIFF
--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "m-charlton"
   ],
+  "contributors": [
+    "kahgoh"
+  ],
   "files": {
     "solution": [
       "custom-set.v"

--- a/exercises/practice/custom-set/.meta/example.v
+++ b/exercises/practice/custom-set/.meta/example.v
@@ -1,44 +1,28 @@
 module main
 
-import arrays { concat }
-import maps { from_array, invert, to_map }
+import arrays { append, distinct, map_of_counts }
 
 /*
-Why use a `map` and not an array?
-- no need to check when adding
-- membership tests faster (no need to check array):
-- an equality test would require both arrays to be in order
-  (i.e sorted)
+Why don't use a map?
+According to the documentation, keys must be either a string, rune,
+integer, float or voidptr.
 */
 struct CustomSet[T] {
 mut:
-	items map[T]u8
+	items []T
 }
 
-@[inline]
-fn (s CustomSet[T]) items() []T {
-	return s.items.keys()
-}
-
-/*
-This needs an explanation:
-
-	elements := ['a', 'b', 'c', 'b']
-	from_array(elements) => { 0: 'a', 1: 'b', 2: 'c', 3: 'b' }
-	invert({ 0: 'a', 1: 'b', 2: 'c', 3`: 'b'}) => { 'a': 0, 'c': 2, 'b': 3 }
-	to_map({ 'a': 0, 'c': 2, 'b': 3}) => { 'a': 1, 'c': 1, 'b': 1 }
-*/
 // build a new CustomSet
 pub fn CustomSet.new[T](elements []T) CustomSet[T] {
-	return CustomSet[T]{
-		items: to_map[T, int, T, u8](invert[int, T](from_array[T](elements)), fn [T](key T, _ int) (T, u8) {
-			return key, 1
-		})
-	}
+  return CustomSet[T] {
+    items: distinct(elements)
+  }
 }
 
 pub fn (mut s CustomSet[T]) add[T](element T) {
-	s.items[element] = 1
+	if !(element in s.items) {
+    s.items << element
+  }
 }
 
 pub fn (s CustomSet[T]) contains[T](element T) bool {
@@ -46,7 +30,7 @@ pub fn (s CustomSet[T]) contains[T](element T) bool {
 }
 
 pub fn (s CustomSet[T]) equal[T](other CustomSet[T]) bool {
-	return s.items.len == other.items.len && s.items == other.items
+	return map_of_counts(s.items) == map_of_counts(other.items)
 }
 
 pub fn (s CustomSet[T]) is_empty[T]() bool {
@@ -55,16 +39,15 @@ pub fn (s CustomSet[T]) is_empty[T]() bool {
 
 // @union to avoid conflict with reserved word 'union'
 pub fn (s CustomSet[T]) @union(other CustomSet[T]) CustomSet[T] {
-	return CustomSet.new(concat(s.items(), ...other.items()))
+  return CustomSet.new[T](append(s.items, other.items))
 }
 
 pub fn (s CustomSet[T]) intersection(other CustomSet[T]) CustomSet[T] {
-	return CustomSet.new[T](other.items().filter(s.contains(it)))
+	return CustomSet.new[T](other.items.filter(it in s.items))
 }
 
 pub fn (s CustomSet[T]) difference[T](other CustomSet[T]) CustomSet[T] {
-	common := s.intersection(other)
-	return CustomSet.new[T](s.items().filter(!common.contains(it)))
+	return CustomSet.new[T](s.items.filter(!other.contains(it)))
 }
 
 pub fn (s CustomSet[T]) is_subset[T](other CustomSet[T]) bool {


### PR DESCRIPTION
This PR follows on from a [fix for a CI error](https://github.com/exercism/vlang/pull/264#issuecomment-3172609051) in custom-set in #264. 

According to [Vlang's documentation](https://github.com/exercism/vlang/pull/264#issuecomment-3172609051), a key of a map __must__ be one of these types:
- string
- rune
- integer
- float
- voidptr

It does not seem to support a generic type for as a key and V would normally give a compile error if an incorrect type is tried (see also https://github.com/vlang/v/issues/25084).

At the moment, the example still seems to work without this change, but I think making this change could help reduce the chance of the CI suddenly failing in the future, with future V releases.
