### PR TITLE
Fix implicit clone warning in satellite example

### DIFF
--- a/exercises/practice/satellite/.meta/example.v
+++ b/exercises/practice/satellite/.meta/example.v
@@ -51,7 +51,7 @@ fn traverse(successor ?rune, mut preorder []rune, mut inorder []rune) !Tree {
 	}
 
 	value := preorder[0]
-	preorder = preorder[1..(preorder.len)]
+	preorder = preorder[1..(preorder.len)].clone()
 
 	left := traverse(value, mut preorder, mut inorder)!
 
@@ -59,7 +59,7 @@ fn traverse(successor ?rune, mut preorder []rune, mut inorder []rune) !Tree {
 		return error('traversals must have the same elements')
 	}
 
-	inorder = inorder[1..(inorder.len)]
+	inorder = inorder[1..(inorder.len)].clone()
 
 	right := traverse(successor, mut preorder, mut inorder)!
 


### PR DESCRIPTION
Fixes the following type of warning:

```
Notice: temp/satellite.v:54:21: notice: an implicit clone of the slice was done here
   52 |
   53 |     value := preorder[0]
   54 |     preorder = preorder[1..(preorder.len)]
      |                        ~~~~~~~~~~~~~~~~~~~
   55 |
   56 |     left := traverse(value, mut preorder, mut inorder)!
Details: temp/satellite.v:54:21: details: To silence this notice, use either an explicit `a[..].clone()`,
or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.
   52 |
   53 |     value := preorder[0]
   54 |     preorder = preorder[1..(preorder.len)]
      |                        ~~~~~~~~~~~~~~~~~~~
   55 |
   56 |     left := traverse(value, mut preorder, mut inorder)
```