### PR TITLE
Fix compile error in circular buffer

### DIFF
--- a/exercises/practice/circular-buffer/.meta/example.v
+++ b/exercises/practice/circular-buffer/.meta/example.v
@@ -17,7 +17,7 @@ pub fn (mut b CircularBuffer[T]) write(value T) ! {
 	if b.content.len >= b.capacity {
 		return error('Buffer is full')
 	}
-	b.content.prepend(value)
+	b.content.prepend([value])
 }
 
 pub fn (mut b CircularBuffer[T]) read() !T {
@@ -33,7 +33,7 @@ pub fn (mut b CircularBuffer[T]) overwrite(value T) {
 		b.content.pop()
 	}
 
-	b.content.prepend(value)
+	b.content.prepend([value])
 }
 
 pub fn (mut b CircularBuffer[T]) clear() {


### PR DESCRIPTION
Fixes the following compiler error due to a recent change in V:

```
  Error: temp/circular_buffer.v:20:20: error: cannot prepend `T` to `[]T`
     18 |         return error('Buffer is full')
     19 |     }
     20 |     b.content.prepend(value)
        |                       ~~~~~
     21 | }
     22 |
  Error: temp/circular_buffer.v:36:20: error: cannot prepend `T` to `[]T`
     34 |     }
     35 |
     36 |     b.content.prepend(value)
        |                       ~~~~~
     37 | }
     38 |
  checker summary: 2 V errors, 0 V warnings, 0 V notices
```

Resolves #277.