### PR TITLE
Revert "Fix compile error in circular buffer (#280)"

### DIFF
--- a/exercises/practice/circular-buffer/.meta/example.v
+++ b/exercises/practice/circular-buffer/.meta/example.v
@@ -17,7 +17,7 @@ pub fn (mut b CircularBuffer[T]) write(value T) ! {
 	if b.content.len >= b.capacity {
 		return error('Buffer is full')
 	}
-	b.content.prepend([value])
+	b.content.prepend(value)
 }
 
 pub fn (mut b CircularBuffer[T]) read() !T {
@@ -33,7 +33,7 @@ pub fn (mut b CircularBuffer[T]) overwrite(value T) {
 		b.content.pop()
 	}
 
-	b.content.prepend([value])
+	b.content.prepend(value)
 }
 
 pub fn (mut b CircularBuffer[T]) clear() {


### PR DESCRIPTION
This reverts commit 8f805f5d293b45d004c851cbb148f55a213d5f9e for #277.

The reason for this is because I just received notification that this has been fixed in the V compiler (see vlang/v#25645 and vlang/v#25585).

Feel free to close this PR without merging if you feel we should keep the fix that was added instead.

