### PR TITLE
Sync simple linked lists

### DIFF
--- a/exercises/practice/simple-linked-list/.meta/tests.toml
+++ b/exercises/practice/simple-linked-list/.meta/tests.toml
@@ -1,0 +1,107 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[962d998c-c203-41e2-8fbd-85a7b98b79b9]
+description = "count -> Empty list has length of zero"
+comment = "In implementations, counts use the len field to support solutions written before this canonical data was added"
+
+[9760262e-d7e4-4639-9840-87e2e2fbb115]
+description = "count -> Singleton list has length of one"
+
+[d9955c90-637c-441b-b41d-8cfb48e924a8]
+description = "count -> Non-empty list has correct length"
+
+[0c3966db-58f9-4632-b94c-8ea13e54c2c8]
+description = "pop -> Pop from empty list is an error"
+
+[a4f9d2e1-7425-49ef-9ee8-6c0cb3407cf0]
+description = "pop -> Can pop from singleton list"
+
+[6dcbb2c9-d98a-47bc-a010-9c19703d3ea2]
+description = "pop -> Can pop from non-empty list"
+
+[e83aade9-f030-4096-aaf0-f9dc6491e6cf]
+description = "pop -> Can pop multiple items"
+
+[5c46bcf2-c0a9-4654-ae17-f3192436fcf1]
+description = "pop -> Pop updates the count"
+
+[70d747a1-2e84-4ebc-bc3f-dcbee6a05f6b]
+description = "push -> Can push to an empty list"
+include = false
+
+[f3197f0a-1fea-45a5-939f-4a5ea60387ec]
+description = "push -> Can push to an empty list"
+reimplements = "70d747a1-2e84-4ebc-bc3f-dcbee6a05f6b"
+
+[391e332e-1f91-4033-b1e0-0e0c17812fa7]
+description = "push -> Can push to a non-empty list"
+
+[ed4b0e01-3bbd-4895-af25-152b5914b3da]
+description = "push -> Push updates count"
+
+[41666790-b932-4e5a-b323-e848a83d12d5]
+description = "push -> Push and pop"
+
+[930a4a5c-76f6-47ec-9be3-4e70993173a1]
+description = "peek -> Peek on empty list is an error"
+
+[43255a50-d919-4e81-afce-e4a271eaedbd]
+description = "peek -> Can peek on singleton list"
+
+[48353020-e25d-4621-a854-e35fb1e15fa7]
+description = "peek -> Can peek on non-empty list"
+
+[96fcead9-a713-46c2-8005-3f246c873851]
+description = "peek -> Peek does not change the count"
+
+[7576ed05-7ff7-4b84-8efb-d34d62c110f5]
+description = "peek -> Can peek after a pop and push"
+
+[b97d00b6-2fab-435d-ae74-3233dcc13698]
+description = "toList LIFO -> Empty linked list to list is empty"
+include = false
+
+[eedeb95f-b5cf-431d-8ad6-5854ba6b251c]
+description = "toList LIFO -> To list with multiple values"
+include = false
+
+[838678de-eaf3-4c14-b34e-7e35b6d851e8]
+description = "toList LIFO -> To list after a pop"
+include = false
+
+[03fc83a5-48a8-470b-a2d2-a286c5e8365f]
+description = "toList FIFO -> Empty linked list to list is empty"
+comment = "to_array is used in place of to_list to maintain support for solutions prior to the canonical data"
+
+[1282484e-a58c-426a-972e-90746bda61fc]
+description = "toList FIFO -> To list with multiple values"
+
+[05ca3109-1249-4c0c-a567-a3b2f8352a7c]
+description = "toList FIFO -> To list after a pop"
+
+[5e6c1a3d-e34b-46d3-be59-3f132a820ed5]
+description = "reverse -> Reversed empty list has same values"
+comment = "Implementation uses to_array to maintain support for solutions prior to the canonical data"
+
+[93c87ed3-862a-474f-820b-ba3fd6b6daf6]
+description = "reverse -> Reversed singleton list is same list"
+
+[92851ebe-9f52-4406-b92e-0718c441a2ab]
+description = "reverse -> Reversed non-empty list is reversed"
+include = false
+
+[1210eeda-b23f-4790-930c-7ac6d0c8e723]
+description = "reverse -> Reversed non-empty list is reversed"
+reimplements = "92851ebe-9f52-4406-b92e-0718c441a2ab"
+
+[9b53af96-7494-4cfa-9b77-b7366fed5c4c]
+description = "reverse -> Double reverse"

--- a/exercises/practice/simple-linked-list/run_test.v
+++ b/exercises/practice/simple-linked-list/run_test.v
@@ -5,16 +5,37 @@ fn test_new() {
 	assert list.len == 0
 }
 
-fn test_push_adds_element_to_the_list() {
-	mut list := new()
-	list.push(1)
-	list.push(2)
+fn test_count_empty_list_has_length_of_zero() {
+	list := new()
+	assert list.len == 0
+}
 
-	if res := list.pop() {
-		assert res == 2
+fn test_count_singleton_list_has_length_of_one() {
+	list := from_array([1])
+
+	assert list.len == 1
+}
+
+fn test_non_empty_list_has_correct_length() {
+	list := from_array([1, 2, 3])
+
+	assert list.len == 3
+}
+
+fn test_pop_returns_nothing_if_the_list_is_empty() {
+	mut list := new()
+
+	if data := list.pop() {
+		assert list.len == 0
+		assert false, 'should return nothing'
 	} else {
-		assert false, 'should return 2'
+		assert true
 	}
+}
+
+fn test_pop_from_singleton_list() {
+	mut list := from_array([1])
+	list.push(1)
 
 	if res := list.pop() {
 		assert res == 1
@@ -23,20 +44,18 @@ fn test_push_adds_element_to_the_list() {
 	}
 }
 
-fn test_push_increments_the_length() {
-	mut list := new()
+fn test_pop_from_non_empty_list() {
+	mut list := from_array([1, 2])
 
-	list.push(1)
-	assert list.len == 1
-
-	list.push(2)
-	assert list.len == 2
+	if res := list.pop() {
+		assert res == 2
+	} else {
+		assert false, 'should return 2'
+	}
 }
 
-fn test_pop_returns_the_head_element_and_removes_it() {
-	mut list := new()
-	list.push(1)
-	list.push(2)
+fn test_pop_can_pop_multiple_items() {
+	mut list := from_array([1, 2])
 
 	if res := list.pop() {
 		assert res == 2
@@ -53,46 +72,87 @@ fn test_pop_returns_the_head_element_and_removes_it() {
 	assert list.is_empty()
 }
 
-fn test_pop_decrements_the_length() {
-	mut list := new()
-	list.push(1)
-	list.push(2)
+fn test_pop_updates_the_count() {
+	mut list := from_array([1, 2])
 
-	list.pop()
+	assert list.len == 2
+
+	if res := list.pop() {
+		assert res == 2
+	} else {
+		assert false, 'should return 2'
+	}
+
 	assert list.len == 1
 
-	list.pop()
+	if res := list.pop() {
+		assert res == 1
+	} else {
+		assert false, 'should return 1'
+	}
 	assert list.len == 0
 }
 
-fn test_pop_returns_nothing_if_the_list_is_empty() {
-	mut list := new()
-
-	if data := list.pop() {
-		assert list.len == 0
-		assert false, 'should return nothing'
-	} else {
-		assert true
-	}
-}
-
-fn test_peek_returns_the_head_element_without_removing_it() {
+fn test_push_to_an_empty_list() {
 	mut list := new()
 	list.push(1)
 
-	if res := list.peek() {
-		assert res == 1
-	} else {
-		assert false, 'should return 1'
-	}
-
-	if res := list.peek() {
-		assert res == 1
-	} else {
-		assert false, 'should return 1'
-	}
-
 	assert list.len == 1
+
+	if res := list.pop() {
+		assert res == 1
+	} else {
+		assert false, 'should return 1'
+	}
+}
+
+fn test_push_to_non_empty_list() {
+	mut list := from_array([1, 2])
+	list.push(3)
+
+	if res := list.pop() {
+		assert res == 3
+	} else {
+		assert false, 'should return 3'
+	}
+}
+
+fn test_push_updates_count() {
+	mut list := from_array([1, 2])
+
+	list.push(3)
+	assert list.len == 3
+}
+
+fn test_push_and_pop() {
+	mut list := new()
+
+	list.push(1)
+	list.push(2)
+
+	if res := list.pop() {
+		assert res == 2
+	} else {
+		assert false, 'should return 2'
+	}
+
+	list.push(3)
+
+	assert list.len == 2
+
+	if res := list.pop() {
+		assert res == 3
+	} else {
+		assert false, 'should return 3'
+	}
+
+	if res := list.pop() {
+		assert res == 1
+	} else {
+		assert false, 'should return 1'
+	}
+
+	assert list.len == 0
 }
 
 fn test_peek_returns_nothing_if_list_is_empty() {
@@ -103,6 +163,89 @@ fn test_peek_returns_nothing_if_list_is_empty() {
 		assert false, 'should return nothing'
 	} else {
 		assert true
+	}
+}
+
+fn test_peek_on_singleton_list() {
+	mut list := from_array([1])
+
+	if data := list.peek() {
+		assert data == 1
+	} else {
+		assert false, 'should return 1'
+	}
+}
+
+fn test_peek_returns_the_head_element_without_removing_it() {
+	mut list := from_array([1])
+
+	if res := list.peek() {
+		assert res == 1
+	} else {
+		assert false, 'should return 1'
+	}
+
+	if res := list.peek() {
+		assert res == 1
+	} else {
+		assert false, 'should return 1'
+	}
+
+	assert list.len == 1
+}
+
+fn test_peek_on_non_empty_list() {
+	mut list := from_array([1, 2])
+
+	if res := list.peek() {
+		assert res == 2
+	} else {
+		assert false, 'should return 2'
+	}
+}
+
+fn test_peek_does_not_change_the_count() {
+	mut list := from_array([1, 2])
+
+	if res := list.peek() {
+		assert res == 2
+	} else {
+		assert false, 'should return 2'
+	}
+
+	assert list.len == 2
+}
+
+fn test_peek_after_pop_and_push() {
+	mut list := new()
+
+	list.push(1)
+	list.push(2)
+
+	if res := list.peek() {
+		assert res == 2
+	} else {
+		assert false, 'should return 2'
+	}
+
+	if res := list.pop() {
+		assert res == 2
+	} else {
+		assert false, 'should return 2'
+	}
+
+	if res := list.peek() {
+		assert res == 1
+	} else {
+		assert false, 'should return 1'
+	}
+
+	list.push(3)
+
+	if res := list.peek() {
+		assert res == 3
+	} else {
+		assert false, 'should return 3'
 	}
 }
 
@@ -136,12 +279,42 @@ fn test_from_array() {
 	}
 }
 
-fn test_to_array() {
-	mut list := new()
+fn test_empty_list_to_array() {
+	list := new()
 	assert list.to_array() == []
+}
 
-	list = from_array([1, 2])
-	assert list.to_array() == [1, 2]
+fn test_non_empty_list_to_array() {
+	list := from_array([1, 2, 3])
+	assert list.to_array() == [1, 2, 3]
+}
+
+fn test_to_array_after_a_pop() {
+	mut list := new()
+
+	list.push(1)
+	list.push(2)
+	list.push(3)
+
+	if res := list.pop() {
+		assert res == 3
+	} else {
+		assert false, 'should return 3'
+	}
+
+	list.push(4)
+
+	assert list.to_array() == [1, 2, 4]
+}
+
+fn test_empty_list_to_array_is_empty() {
+	list := new()
+	assert list.to_array() == []
+}
+
+fn test_to_array_with_multiple_values() {
+	list := from_array([1, 2, 3])
+	assert list.to_array() == [1, 2, 3]
 }
 
 fn test_to_array_does_not_mutate_the_list() {
@@ -150,11 +323,33 @@ fn test_to_array_does_not_mutate_the_list() {
 	assert list.len == 3
 }
 
-fn test_reverse() {
+fn test_reverse_empty_list() {
+	mut list := new()
+	mut reversed_list := list.reverse()
+
+	assert reversed_list.to_array() == []
+}
+
+fn test_reverse_singleton_empty_list() {
+	mut list := from_array([1])
+	mut reversed_list := list.reverse()
+
+	assert reversed_list.to_array() == [1]
+}
+
+fn test_reverse_non_empty_list() {
 	mut list := from_array([1, 2, 3])
 	mut reversed_list := list.reverse()
 
 	assert reversed_list.to_array() == [3, 2, 1]
+}
+
+fn test_double_reverse() {
+	mut list := from_array([1, 2, 3])
+	mut reverserd_list_1 := list.reverse()
+	mut reverserd_list_2 := reverserd_list_1.reverse()
+
+	assert reverserd_list_2.to_array() == [1, 2, 3]
 }
 
 fn test_reverse_does_not_mutate_the_list() {


### PR DESCRIPTION
This updates the exercise to sync the canonical test data. Note, this change also attempts to maintain support for solutions written before the canonical data was added. The test differs from the canonical data in the following ways:
- len property is used in place of a dedicated count() function
- to_array is used in place of to_list
- to_array is used for validation in the reverse tests